### PR TITLE
feat: message timestamp in subscription payload

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+# Description
+
+<!--
+Please include:
+* summary of the changes and the related issue
+* relevant motivation and context
+-->
+
+Resolves # (issue)
+
+## How Has This Been Tested?
+
+<!--
+Please:
+* describe the tests that you ran to verify your changes.
+* provide instructions so we can reproduce.
+-->
+
+<!-- If valid for smoke test on feature add screenshots -->
+
+## Due Diligence
+
+* [ ] Breaking change
+* [ ] Requires a documentation update
+* [ ] Requires a e2e/integration test update

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -443,6 +443,7 @@ impl Publish {
         &self,
         message_id: MessageId,
         subscription_id: SubscriptionId,
+        published_at: i64,
     ) -> Request {
         Request {
             id: message_id,
@@ -452,6 +453,7 @@ impl Publish {
                 data: SubscriptionData {
                     topic: self.topic.clone(),
                     message: self.message.clone(),
+                    published_at,
                 },
             }),
         }
@@ -542,12 +544,16 @@ impl RequestPayload for Subscription {
 
 /// Data structure representing subscription message params.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SubscriptionData {
     /// The topic of the subscription.
     pub topic: Topic,
 
     /// The message for the subscription.
     pub message: Arc<str>,
+
+    /// Message publish timestamp in UTC milliseconds.
+    pub published_at: i64,
 }
 
 /// Enum representing parameters of all possible RPC requests.

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -91,6 +91,7 @@ fn subscription() {
     let data = SubscriptionData {
         topic: "test_topic".into(),
         message: "test_message".into(),
+        published_at: 123,
     };
     let params = Subscription {
         id: "test_id".into(),
@@ -102,7 +103,7 @@ fn subscription() {
 
     assert_eq!(
         &serialized,
-        r#"{"id":1,"jsonrpc":"2.0","method":"irn_subscription","params":{"id":"test_id","data":{"topic":"test_topic","message":"test_message"}}}"#
+        r#"{"id":1,"jsonrpc":"2.0","method":"irn_subscription","params":{"id":"test_id","data":{"topic":"test_topic","message":"test_message","publishedAt":123}}}"#
     );
 
     let deserialized: Payload = serde_json::from_str(&serialized).unwrap();
@@ -112,7 +113,7 @@ fn subscription() {
 
 #[test]
 fn deserialize_iridium_method() {
-    let serialized = r#"{"id":1,"jsonrpc":"2.0","method":"iridium_subscription","params":{"id":"test_id","data":{"topic":"test_topic","message":"test_message"}}}"#;
+    let serialized = r#"{"id":1,"jsonrpc":"2.0","method":"iridium_subscription","params":{"id":"test_id","data":{"topic":"test_topic","message":"test_message","publishedAt":123}}}"#;
     assert!(serde_json::from_str::<'_, Payload>(serialized).is_ok());
 }
 
@@ -315,6 +316,7 @@ fn validation() {
             data: SubscriptionData {
                 topic: topic.clone(),
                 message: message.clone(),
+                published_at: 123,
             },
         }),
     };
@@ -329,6 +331,7 @@ fn validation() {
             data: SubscriptionData {
                 topic: topic.clone(),
                 message: message.clone(),
+                published_at: 123,
             },
         }),
     };
@@ -348,6 +351,7 @@ fn validation() {
             data: SubscriptionData {
                 topic: Topic::from("invalid"),
                 message,
+                published_at: 123,
             },
         }),
     };
@@ -365,6 +369,7 @@ fn validation() {
             data: SubscriptionData {
                 topic: topic.clone(),
                 message: "0".repeat(MAX_MESSAGE_LENGTH + 1).into(),
+                published_at: 123,
             },
         }),
     };


### PR DESCRIPTION
# Description

This adds the `publishedAt` timestamp to the `Subscription` RPC payload. See [the specs](https://github.com/WalletConnect/walletconnect-docs/pull/473).

## How Has This Been Tested?

Unit tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update