### PR TITLE
feat: add tag field to subscription data struct

### DIFF
--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -438,6 +438,7 @@ impl Publish {
                     topic: self.topic.clone(),
                     message: self.message.clone(),
                     published_at,
+                    tag: self.tag,
                 },
             }),
         }
@@ -530,6 +531,10 @@ pub struct SubscriptionData {
 
     /// Message publish timestamp in UTC milliseconds.
     pub published_at: i64,
+
+    /// A label that identifies what type of message is sent based on the RPC
+    /// method used.
+    pub tag: u32,
 }
 
 /// Enum representing parameters of all possible RPC requests.

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -92,6 +92,7 @@ fn subscription() {
         topic: "test_topic".into(),
         message: "test_message".into(),
         published_at: 123,
+        tag: 1000,
     };
     let params = Subscription {
         id: "test_id".into(),
@@ -103,7 +104,7 @@ fn subscription() {
 
     assert_eq!(
         &serialized,
-        r#"{"id":1,"jsonrpc":"2.0","method":"irn_subscription","params":{"id":"test_id","data":{"topic":"test_topic","message":"test_message","publishedAt":123}}}"#
+        r#"{"id":1,"jsonrpc":"2.0","method":"irn_subscription","params":{"id":"test_id","data":{"topic":"test_topic","message":"test_message","publishedAt":123,"tag":1000}}}"#
     );
 
     let deserialized: Payload = serde_json::from_str(&serialized).unwrap();
@@ -113,7 +114,7 @@ fn subscription() {
 
 #[test]
 fn deserialize_iridium_method() {
-    let serialized = r#"{"id":1,"jsonrpc":"2.0","method":"iridium_subscription","params":{"id":"test_id","data":{"topic":"test_topic","message":"test_message","publishedAt":123}}}"#;
+    let serialized = r#"{"id":1,"jsonrpc":"2.0","method":"iridium_subscription","params":{"id":"test_id","data":{"topic":"test_topic","message":"test_message","publishedAt":123,"tag":1000}}}"#;
     assert!(serde_json::from_str::<'_, Payload>(serialized).is_ok());
 }
 
@@ -303,6 +304,7 @@ fn validation() {
                 topic: topic.clone(),
                 message: message.clone(),
                 published_at: 123,
+                tag: 1000,
             },
         }),
     };
@@ -318,6 +320,7 @@ fn validation() {
                 topic: topic.clone(),
                 message: message.clone(),
                 published_at: 123,
+                tag: 1000,
             },
         }),
     };
@@ -338,6 +341,7 @@ fn validation() {
                 topic: Topic::from("invalid"),
                 message,
                 published_at: 123,
+                tag: 1000,
             },
         }),
     };


### PR DESCRIPTION
# Description

Add `tag` field to `SubscriptionData` field, so that subscribers can be aware of the type of incoming message. 

E.g. Cast server will be able to distinguish `pushDelete` without having to decrypt the message.

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
