### PR TITLE
fix: use rustls and switch ConnectionHandler to async_trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ relay_rpc = { path = "./relay_rpc", optional = true }
 
 [dev-dependencies]
 anyhow = "1"
+async-trait = "0.1"
 structopt = { version = "0.3", default-features = false }
 tokio = { version = "1.22", features = ["full"] }
 

--- a/examples/basic_client.rs
+++ b/examples/basic_client.rs
@@ -1,4 +1,5 @@
 use {
+    async_trait::async_trait,
     relay_client::{
         Client,
         CloseFrame,
@@ -36,27 +37,28 @@ impl Handler {
     }
 }
 
+#[async_trait]
 impl ConnectionHandler for Handler {
-    fn connected(&mut self) {
+    async fn connected(&mut self) {
         println!("[{}] connection open", self.name);
     }
 
-    fn disconnected(&mut self, frame: Option<CloseFrame<'static>>) {
+    async fn disconnected(&mut self, frame: Option<CloseFrame<'static>>) {
         println!("[{}] connection closed: frame={frame:?}", self.name);
     }
 
-    fn message_received(&mut self, message: PublishedMessage) {
+    async fn message_received(&mut self, message: PublishedMessage) {
         println!(
             "[{}] inbound message: topic={} message={}",
             self.name, message.topic, message.message
         );
     }
 
-    fn inbound_error(&mut self, error: Error) {
+    async fn inbound_error(&mut self, error: Error) {
         println!("[{}] inbound error: {error}", self.name);
     }
 
-    fn outbound_error(&mut self, error: Error) {
+    async fn outbound_error(&mut self, error: Error) {
         println!("[{}] outbound error: {error}", self.name);
     }
 }

--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -8,7 +8,7 @@ relay_rpc = { path = "../relay_rpc" }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 thiserror = "1.0"
 tokio = { version = "1.22", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }
-tokio-tungstenite = { version = "0.17", features = ["connect", "native-tls"] }
+tokio-tungstenite = { version = "0.18", features = ["rustls-tls-native-roots"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.10"

--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+async-trait = "0.1"
 relay_rpc = { path = "../relay_rpc" }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 thiserror = "1.0"

--- a/relay_client/src/client.rs
+++ b/relay_client/src/client.rs
@@ -1,6 +1,7 @@
 use {
     self::connection::{connection_event_loop, ConnectionControl},
     crate::{ConnectionOptions, Error},
+    async_trait::async_trait,
     relay_rpc::{
         domain::{SubscriptionId, Topic},
         rpc::{BatchSubscribe, BatchUnsubscribe, Publish, Subscribe, Subscription, Unsubscribe},
@@ -44,23 +45,24 @@ impl PublishedMessage {
 }
 
 /// Handlers for the RPC stream events.
+#[async_trait]
 pub trait ConnectionHandler: Send + 'static {
     /// Called when a connection to the Relay is established.
-    fn connected(&mut self) {}
+    async fn connected(&mut self) {}
 
     /// Called when the Relay connection is closed.
-    fn disconnected(&mut self, _frame: Option<CloseFrame<'static>>) {}
+    async fn disconnected(&mut self, _frame: Option<CloseFrame<'static>>) {}
 
     /// Called when a message is received from the Relay.
-    fn message_received(&mut self, message: PublishedMessage);
+    async fn message_received(&mut self, message: PublishedMessage);
 
     /// Called when an inbound error occurs, such as data deserialization
     /// failure, or an unknown response message ID.
-    fn inbound_error(&mut self, _error: Error) {}
+    async fn inbound_error(&mut self, _error: Error) {}
 
     /// Called when an outbound error occurs, i.e. failed to write to the
     /// websocket stream.
-    fn outbound_error(&mut self, _error: Error) {}
+    async fn outbound_error(&mut self, _error: Error) {}
 }
 
 /// The Relay RPC client.


### PR DESCRIPTION
# Description

1. switch to rustls in tokio-tungstenite: we find rustls to be more portable, so we prefer using that. Maybe both native-tls and rustls can be made features of the client if someone prefers native-tls?
2. switch ConnectionHandler to async_trait: we use tokio's sync primitives (async Mutex or channels), so with the old trait, one will need to e.g. call `blocking_lock` in the ConnectionHandler implementation... but that would panic, because the SDK's client will execute ConnectionHandler in an asynchronous context. So if ConnectionHandler was kept synchronous, it'd either require SDK to use `spawn_blocking` on ConnectionHandler's handler methods or the docs should say the implementor should make sure to use `block_in_place` in their methods... Anyway, the simplest solution seems to be to make ConnectionHandler asynchronous.

Resolves # N/A

## How Has This Been Tested?

using `cargo run --example basic_client --features full`, plus a custom partial Sign API implementation

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
