### PR TITLE
fix: feature to allow switching to rustls

### DIFF
--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -3,12 +3,16 @@ name = "relay_client"
 version = "0.1.0"
 edition = "2021"
 
+[features]
+default = ["tokio-tungstenite/native-tls"]
+rustls = ["tokio-tungstenite/rustls-tls-native-roots"]
+
 [dependencies]
 relay_rpc = { path = "../relay_rpc" }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 thiserror = "1.0"
 tokio = { version = "1.22", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }
-tokio-tungstenite = { version = "0.17", features = ["connect", "native-tls"] }
+tokio-tungstenite = "0.18"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_qs = "0.10"


### PR DESCRIPTION
# Description

allow switching to rustls in tokio-tungstenite: we find rustls to be more portable, so we prefer using that

Resolves # N/A #9

## How Has This Been Tested?

using `cargo run --example basic_client --features full`, plus a custom partial Sign API implementation

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
