### PR TITLE
feat: fetch api

### DIFF
--- a/relay_client/src/client.rs
+++ b/relay_client/src/client.rs
@@ -4,10 +4,10 @@ use {
     relay_rpc::{
         domain::{SubscriptionId, Topic},
         rpc::{
-            BatchFetch,
+            BatchFetchMessages,
             BatchSubscribe,
             BatchUnsubscribe,
-            Fetch,
+            FetchMessages,
             Publish,
             Subscribe,
             Subscription,
@@ -142,8 +142,8 @@ impl Client {
     }
 
     /// Fetch mailbox messages for a specific topic.
-    pub fn fetch(&self, topic: Topic) -> ResponseFuture<Fetch> {
-        let (request, response) = create_request(Fetch { topic });
+    pub fn fetch(&self, topic: Topic) -> ResponseFuture<FetchMessages> {
+        let (request, response) = create_request(FetchMessages { topic });
 
         self.request(request);
 
@@ -181,8 +181,8 @@ impl Client {
     }
 
     /// Fetch mailbox messages for multiple topics.
-    pub fn batch_fetch(&self, topics: impl Into<Vec<Topic>>) -> ResponseFuture<BatchFetch> {
-        let (request, response) = create_request(BatchFetch {
+    pub fn batch_fetch(&self, topics: impl Into<Vec<Topic>>) -> ResponseFuture<BatchFetchMessages> {
+        let (request, response) = create_request(BatchFetchMessages {
             topics: topics.into(),
         });
 

--- a/relay_client/src/client/fetch.rs
+++ b/relay_client/src/client/fetch.rs
@@ -1,0 +1,104 @@
+use {
+    crate::{create_request, Client, Error, ResponseFuture},
+    futures_util::{FutureExt, Stream},
+    relay_rpc::{
+        domain::Topic,
+        rpc::{BatchFetch, SubscriptionData},
+    },
+    std::{
+        pin::Pin,
+        task::{Context, Poll},
+    },
+};
+
+/// Stream that uses the `irn_batchFetch` RPC method to retrieve messages from
+/// the Relay.
+pub struct FetchMessageStream {
+    client: Client,
+    request: BatchFetch,
+    batch: Option<std::vec::IntoIter<SubscriptionData>>,
+    batch_fut: Option<ResponseFuture<BatchFetch>>,
+    has_more: bool,
+}
+
+impl FetchMessageStream {
+    pub(super) fn new(client: Client, topics: impl Into<Vec<Topic>>) -> Self {
+        let request = BatchFetch {
+            topics: topics.into(),
+        };
+
+        Self {
+            client,
+            request,
+            batch: None,
+            batch_fut: None,
+            has_more: true,
+        }
+    }
+
+    /// Clears all internal state so that on the next stream poll it returns
+    /// `None` and finishes data streaming.
+    #[inline]
+    fn clear(&mut self) {
+        self.batch = None;
+        self.batch_fut = None;
+        self.has_more = false;
+    }
+}
+
+impl Stream for FetchMessageStream {
+    type Item = Result<SubscriptionData, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        loop {
+            if let Some(batch) = &mut self.batch {
+                // Drain the items from the batch, if we have one.
+                match batch.next() {
+                    Some(data) => {
+                        return Poll::Ready(Some(Ok(data)));
+                    }
+
+                    None => {
+                        // No more items in the batch, fetch the next batch.
+                        self.batch = None;
+                    }
+                }
+            } else if let Some(batch_fut) = &mut self.batch_fut {
+                // Waiting for the next batch to arrive.
+                match batch_fut.poll_unpin(cx) {
+                    // The next batch is ready. Update `has_more` flag and clear the batch future.
+                    Poll::Ready(Ok(response)) => {
+                        self.batch = Some(response.messages.into_iter());
+                        self.batch_fut = None;
+                        self.has_more = response.has_more;
+                    }
+
+                    // Error receiving the next batch. This is unrecoverable, so clear the state and
+                    // end the stream.
+                    Poll::Ready(Err(err)) => {
+                        self.clear();
+
+                        return Poll::Ready(Some(Err(err)));
+                    }
+
+                    // The batch is not ready yet.
+                    Poll::Pending => {
+                        return Poll::Pending;
+                    }
+                };
+            } else if self.has_more {
+                // We have neither a batch, or a batch future, but `has_more` flag is set. Set
+                // up a future to receive the next batch.
+                let (request, batch_fut) = create_request(self.request.clone());
+
+                self.client.request(request);
+                self.batch_fut = Some(batch_fut);
+            } else {
+                // The stream can't produce any more items, since it doesn't have neither a
+                // batch of data or a future for receiving the next batch, and `has_more` flag
+                // is not set.
+                return Poll::Ready(None);
+            }
+        }
+    }
+}

--- a/relay_client/src/client/fetch.rs
+++ b/relay_client/src/client/fetch.rs
@@ -3,7 +3,7 @@ use {
     futures_util::{FutureExt, Stream},
     relay_rpc::{
         domain::Topic,
-        rpc::{BatchFetch, SubscriptionData},
+        rpc::{BatchFetchMessages, SubscriptionData},
     },
     std::{
         pin::Pin,
@@ -15,15 +15,15 @@ use {
 /// the Relay.
 pub struct FetchMessageStream {
     client: Client,
-    request: BatchFetch,
+    request: BatchFetchMessages,
     batch: Option<std::vec::IntoIter<SubscriptionData>>,
-    batch_fut: Option<ResponseFuture<BatchFetch>>,
+    batch_fut: Option<ResponseFuture<BatchFetchMessages>>,
     has_more: bool,
 }
 
 impl FetchMessageStream {
     pub(super) fn new(client: Client, topics: impl Into<Vec<Topic>>) -> Self {
-        let request = BatchFetch {
+        let request = BatchFetchMessages {
             topics: topics.into(),
         };
 

--- a/relay_rpc/src/auth.rs
+++ b/relay_rpc/src/auth.rs
@@ -158,7 +158,7 @@ pub fn encode_auth_token(
     let iss = {
         let client_id = DecodedClientId(*key.public_key().as_bytes());
 
-        format!("{DID_PREFIX}{DID_DELIMITER}{DID_METHOD}{DID_DELIMITER}{client_id}",)
+        format!("{DID_PREFIX}{DID_DELIMITER}{DID_METHOD}{DID_DELIMITER}{client_id}")
     };
 
     let claims = {

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -21,6 +21,11 @@ pub static JSON_RPC_VERSION: once_cell::sync::Lazy<Arc<str>> =
 /// See <https://github.com/WalletConnect/walletconnect-docs/blob/main/docs/specs/servers/relay/relay-server-rpc.md>
 pub const MAX_SUBSCRIPTION_BATCH_SIZE: usize = 500;
 
+/// The maximum number of topics allowed for a batch fetch request.
+///
+/// See <https://github.com/WalletConnect/walletconnect-docs/blob/main/docs/specs/servers/relay/relay-server-rpc.md>
+pub const MAX_FETCH_BATCH_SIZE: usize = 500;
+
 type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Errors covering payload validation problems.
@@ -35,14 +40,11 @@ pub enum ValidationError {
     #[error("Invalid JSON RPC version")]
     JsonRpcVersion,
 
-    #[error(
-        "The batch contains too many items. Maximum number of subscriptions is {}",
-        MAX_SUBSCRIPTION_BATCH_SIZE
-    )]
-    BatchSubscriptionLimit,
+    #[error("The batch contains too many items ({actual}). Maximum number of items is {limit}")]
+    BatchLimitExceeded { limit: usize, actual: usize },
 
     #[error("The batch contains no items")]
-    BatchSubscriptionListEmpty,
+    BatchEmpty,
 }
 
 /// Errors caught while processing the request. These are meant to be serialized
@@ -333,6 +335,42 @@ impl RequestPayload for Unsubscribe {
     }
 }
 
+/// Data structure representing fetch request params.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct Fetch {
+    /// The topic of the messages to fetch.
+    pub topic: Topic,
+}
+
+impl RequestPayload for Fetch {
+    type Error = GenericError;
+    type Response = FetchResponse;
+
+    fn validate(&self) -> Result<(), ValidationError> {
+        self.topic
+            .decode()
+            .map_err(ValidationError::TopicDecoding)?;
+
+        Ok(())
+    }
+
+    fn into_params(self) -> Params {
+        Params::Fetch(self)
+    }
+}
+
+/// Data structure representing fetch response.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FetchResponse {
+    /// Array of messages fetched from the mailbox.
+    pub messages: Vec<SubscriptionData>,
+
+    /// Flag that indicates whether the client should keep fetching the
+    /// messages.
+    pub has_more: bool,
+}
+
 /// Multi-topic subscription request parameters.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct BatchSubscribe {
@@ -345,12 +383,17 @@ impl RequestPayload for BatchSubscribe {
     type Response = Vec<SubscriptionId>;
 
     fn validate(&self) -> Result<(), ValidationError> {
-        if self.topics.is_empty() {
-            return Err(ValidationError::BatchSubscriptionListEmpty);
+        let batch_size = self.topics.len();
+
+        if batch_size == 0 {
+            return Err(ValidationError::BatchEmpty);
         }
 
-        if self.topics.len() > MAX_SUBSCRIPTION_BATCH_SIZE {
-            return Err(ValidationError::BatchSubscriptionLimit);
+        if batch_size > MAX_SUBSCRIPTION_BATCH_SIZE {
+            return Err(ValidationError::BatchLimitExceeded {
+                limit: MAX_SUBSCRIPTION_BATCH_SIZE,
+                actual: batch_size,
+            });
         }
 
         for topic in &self.topics {
@@ -377,12 +420,17 @@ impl RequestPayload for BatchUnsubscribe {
     type Response = bool;
 
     fn validate(&self) -> Result<(), ValidationError> {
-        if self.subscriptions.is_empty() {
-            return Err(ValidationError::BatchSubscriptionListEmpty);
+        let batch_size = self.subscriptions.len();
+
+        if batch_size == 0 {
+            return Err(ValidationError::BatchEmpty);
         }
 
-        if self.subscriptions.len() > MAX_SUBSCRIPTION_BATCH_SIZE {
-            return Err(ValidationError::BatchSubscriptionLimit);
+        if batch_size > MAX_SUBSCRIPTION_BATCH_SIZE {
+            return Err(ValidationError::BatchLimitExceeded {
+                limit: MAX_SUBSCRIPTION_BATCH_SIZE,
+                actual: batch_size,
+            });
         }
 
         for sub in &self.subscriptions {
@@ -394,6 +442,43 @@ impl RequestPayload for BatchUnsubscribe {
 
     fn into_params(self) -> Params {
         Params::BatchUnsubscribe(self)
+    }
+}
+
+/// Data structure representing batch fetch request params.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct BatchFetch {
+    /// The topics of the messages to fetch.
+    pub topics: Vec<Topic>,
+}
+
+impl RequestPayload for BatchFetch {
+    type Error = GenericError;
+    type Response = FetchResponse;
+
+    fn validate(&self) -> Result<(), ValidationError> {
+        let batch_size = self.topics.len();
+
+        if batch_size == 0 {
+            return Err(ValidationError::BatchEmpty);
+        }
+
+        if batch_size > MAX_FETCH_BATCH_SIZE {
+            return Err(ValidationError::BatchLimitExceeded {
+                limit: MAX_FETCH_BATCH_SIZE,
+                actual: batch_size,
+            });
+        }
+
+        for topic in &self.topics {
+            topic.decode().map_err(ValidationError::TopicDecoding)?;
+        }
+
+        Ok(())
+    }
+
+    fn into_params(self) -> Params {
+        Params::BatchFetch(self)
     }
 }
 
@@ -550,6 +635,10 @@ pub enum Params {
     #[serde(rename = "irn_unsubscribe", alias = "iridium_unsubscribe")]
     Unsubscribe(Unsubscribe),
 
+    /// Parameters to fetch.
+    #[serde(rename = "irn_fetch", alias = "iridium_fetch")]
+    Fetch(Fetch),
+
     /// Parameters to batch subscribe.
     #[serde(rename = "irn_batchSubscribe", alias = "iridium_batchSubscribe")]
     BatchSubscribe(BatchSubscribe),
@@ -557,6 +646,10 @@ pub enum Params {
     /// Parameters to batch unsubscribe.
     #[serde(rename = "irn_batchUnsubscribe", alias = "iridium_batchUnsubscribe")]
     BatchUnsubscribe(BatchUnsubscribe),
+
+    /// Parameters to batch fetch.
+    #[serde(rename = "irn_batchFetch", alias = "iridium_batchFetch")]
+    BatchFetch(BatchFetch),
 
     /// Parameters to publish.
     #[serde(rename = "irn_publish", alias = "iridium_publish")]
@@ -603,8 +696,10 @@ impl Request {
         match &self.params {
             Params::Subscribe(params) => params.validate(),
             Params::Unsubscribe(params) => params.validate(),
+            Params::Fetch(params) => params.validate(),
             Params::BatchSubscribe(params) => params.validate(),
             Params::BatchUnsubscribe(params) => params.validate(),
+            Params::BatchFetch(params) => params.validate(),
             Params::Publish(params) => params.validate(),
             Params::Subscription(params) => params.validate(),
         }

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -337,12 +337,12 @@ impl RequestPayload for Unsubscribe {
 
 /// Data structure representing fetch request params.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct Fetch {
+pub struct FetchMessages {
     /// The topic of the messages to fetch.
     pub topic: Topic,
 }
 
-impl RequestPayload for Fetch {
+impl RequestPayload for FetchMessages {
     type Error = GenericError;
     type Response = FetchResponse;
 
@@ -355,7 +355,7 @@ impl RequestPayload for Fetch {
     }
 
     fn into_params(self) -> Params {
-        Params::Fetch(self)
+        Params::FetchMessages(self)
     }
 }
 
@@ -447,12 +447,12 @@ impl RequestPayload for BatchUnsubscribe {
 
 /// Data structure representing batch fetch request params.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct BatchFetch {
+pub struct BatchFetchMessages {
     /// The topics of the messages to fetch.
     pub topics: Vec<Topic>,
 }
 
-impl RequestPayload for BatchFetch {
+impl RequestPayload for BatchFetchMessages {
     type Error = GenericError;
     type Response = FetchResponse;
 
@@ -478,7 +478,7 @@ impl RequestPayload for BatchFetch {
     }
 
     fn into_params(self) -> Params {
-        Params::BatchFetch(self)
+        Params::BatchFetchMessages(self)
     }
 }
 
@@ -636,8 +636,8 @@ pub enum Params {
     Unsubscribe(Unsubscribe),
 
     /// Parameters to fetch.
-    #[serde(rename = "irn_fetch", alias = "iridium_fetch")]
-    Fetch(Fetch),
+    #[serde(rename = "irn_fetchMessages", alias = "iridium_fetchMessages")]
+    FetchMessages(FetchMessages),
 
     /// Parameters to batch subscribe.
     #[serde(rename = "irn_batchSubscribe", alias = "iridium_batchSubscribe")]
@@ -648,8 +648,11 @@ pub enum Params {
     BatchUnsubscribe(BatchUnsubscribe),
 
     /// Parameters to batch fetch.
-    #[serde(rename = "irn_batchFetch", alias = "iridium_batchFetch")]
-    BatchFetch(BatchFetch),
+    #[serde(
+        rename = "irn_batchFetchMessages",
+        alias = "iridium_batchFetchMessages"
+    )]
+    BatchFetchMessages(BatchFetchMessages),
 
     /// Parameters to publish.
     #[serde(rename = "irn_publish", alias = "iridium_publish")]
@@ -696,10 +699,10 @@ impl Request {
         match &self.params {
             Params::Subscribe(params) => params.validate(),
             Params::Unsubscribe(params) => params.validate(),
-            Params::Fetch(params) => params.validate(),
+            Params::FetchMessages(params) => params.validate(),
             Params::BatchSubscribe(params) => params.validate(),
             Params::BatchUnsubscribe(params) => params.validate(),
-            Params::BatchFetch(params) => params.validate(),
+            Params::BatchFetchMessages(params) => params.validate(),
             Params::Publish(params) => params.validate(),
             Params::Subscription(params) => params.validate(),
         }

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -298,7 +298,7 @@ fn validation() {
     let request = Request {
         id,
         jsonrpc: jsonrpc.clone(),
-        params: Params::Fetch(Fetch {
+        params: Params::FetchMessages(FetchMessages {
             topic: topic.clone(),
         }),
     };
@@ -308,7 +308,7 @@ fn validation() {
     let request = Request {
         id,
         jsonrpc: jsonrpc.clone(),
-        params: Params::Fetch(Fetch {
+        params: Params::FetchMessages(FetchMessages {
             topic: Topic::from("invalid"),
         }),
     };
@@ -488,7 +488,7 @@ fn validation() {
     let request = Request {
         id,
         jsonrpc: jsonrpc.clone(),
-        params: Params::BatchFetch(BatchFetch {
+        params: Params::BatchFetchMessages(BatchFetchMessages {
             topics: vec![Topic::generate()],
         }),
     };
@@ -498,7 +498,7 @@ fn validation() {
     let request = Request {
         id,
         jsonrpc: jsonrpc.clone(),
-        params: Params::BatchFetch(BatchFetch { topics: vec![] }),
+        params: Params::BatchFetchMessages(BatchFetchMessages { topics: vec![] }),
     };
     assert_eq!(request.validate(), Err(ValidationError::BatchEmpty));
 
@@ -509,7 +509,7 @@ fn validation() {
     let request = Request {
         id,
         jsonrpc: jsonrpc.clone(),
-        params: Params::BatchFetch(BatchFetch { topics }),
+        params: Params::BatchFetchMessages(BatchFetchMessages { topics }),
     };
     assert_eq!(
         request.validate(),
@@ -523,7 +523,7 @@ fn validation() {
     let request = Request {
         id,
         jsonrpc,
-        params: Params::BatchFetch(BatchFetch {
+        params: Params::BatchFetchMessages(BatchFetchMessages {
             topics: vec![Topic::from(
                 "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c98401",
             )],

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -366,10 +366,7 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchSubscribe(BatchSubscribe { topics: vec![] }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::BatchSubscriptionListEmpty)
-    );
+    assert_eq!(request.validate(), Err(ValidationError::BatchEmpty));
 
     // Batch subscription: too many items.
     let topics = (0..MAX_SUBSCRIPTION_BATCH_SIZE + 1)
@@ -382,7 +379,10 @@ fn validation() {
     };
     assert_eq!(
         request.validate(),
-        Err(ValidationError::BatchSubscriptionLimit)
+        Err(ValidationError::BatchLimitExceeded {
+            limit: MAX_SUBSCRIPTION_BATCH_SIZE,
+            actual: MAX_SUBSCRIPTION_BATCH_SIZE + 1
+        })
     );
 
     // Batch subscription: invalid topic.
@@ -421,10 +421,7 @@ fn validation() {
             subscriptions: vec![],
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::BatchSubscriptionListEmpty)
-    );
+    assert_eq!(request.validate(), Err(ValidationError::BatchEmpty));
 
     // Batch unsubscription: too many items.
     let subscriptions = (0..MAX_SUBSCRIPTION_BATCH_SIZE + 1)
@@ -440,7 +437,10 @@ fn validation() {
     };
     assert_eq!(
         request.validate(),
-        Err(ValidationError::BatchSubscriptionLimit)
+        Err(ValidationError::BatchLimitExceeded {
+            limit: MAX_SUBSCRIPTION_BATCH_SIZE,
+            actual: MAX_SUBSCRIPTION_BATCH_SIZE + 1
+        })
     );
 
     // Batch unsubscription: invalid topic.

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -294,6 +294,29 @@ fn validation() {
         Err(ValidationError::TopicDecoding(DecodingError::Length))
     );
 
+    // Fetch: valid.
+    let request = Request {
+        id,
+        jsonrpc: jsonrpc.clone(),
+        params: Params::Fetch(Fetch {
+            topic: topic.clone(),
+        }),
+    };
+    assert_eq!(request.validate(), Ok(()));
+
+    // Fetch: invalid topic.
+    let request = Request {
+        id,
+        jsonrpc: jsonrpc.clone(),
+        params: Params::Fetch(Fetch {
+            topic: Topic::from("invalid"),
+        }),
+    };
+    assert_eq!(
+        request.validate(),
+        Err(ValidationError::TopicDecoding(DecodingError::Length))
+    );
+
     // Subscription: valid.
     let request = Request {
         id,
@@ -446,7 +469,7 @@ fn validation() {
     // Batch unsubscription: invalid topic.
     let request = Request {
         id,
-        jsonrpc,
+        jsonrpc: jsonrpc.clone(),
         params: Params::BatchUnsubscribe(BatchUnsubscribe {
             subscriptions: vec![Unsubscribe {
                 topic: Topic::from(
@@ -454,6 +477,56 @@ fn validation() {
                 ),
                 subscription_id,
             }],
+        }),
+    };
+    assert_eq!(
+        request.validate(),
+        Err(ValidationError::TopicDecoding(DecodingError::Length))
+    );
+
+    // Batch fetch: valid.
+    let request = Request {
+        id,
+        jsonrpc: jsonrpc.clone(),
+        params: Params::BatchFetch(BatchFetch {
+            topics: vec![Topic::generate()],
+        }),
+    };
+    assert_eq!(request.validate(), Ok(()));
+
+    // Batch fetch: empty list.
+    let request = Request {
+        id,
+        jsonrpc: jsonrpc.clone(),
+        params: Params::BatchFetch(BatchFetch { topics: vec![] }),
+    };
+    assert_eq!(request.validate(), Err(ValidationError::BatchEmpty));
+
+    // Batch fetch: too many items.
+    let topics = (0..MAX_SUBSCRIPTION_BATCH_SIZE + 1)
+        .map(|_| Topic::generate())
+        .collect();
+    let request = Request {
+        id,
+        jsonrpc: jsonrpc.clone(),
+        params: Params::BatchFetch(BatchFetch { topics }),
+    };
+    assert_eq!(
+        request.validate(),
+        Err(ValidationError::BatchLimitExceeded {
+            limit: MAX_SUBSCRIPTION_BATCH_SIZE,
+            actual: MAX_SUBSCRIPTION_BATCH_SIZE + 1
+        })
+    );
+
+    // Batch fetch: invalid topic.
+    let request = Request {
+        id,
+        jsonrpc,
+        params: Params::BatchFetch(BatchFetch {
+            topics: vec![Topic::from(
+                "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c98401",
+            )],
         }),
     };
     assert_eq!(


### PR DESCRIPTION
# Description

This adds the payload and client methods for the new `irn_fetchMessages` and `irn_batchFetchMessages` RPC. See https://github.com/WalletConnect/walletconnect-docs/pull/459 for specs.

Note: The `fetch_stream()` API is actually covered with tests in the relay.

## How Has This Been Tested?

Manually + relay integration tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
