### PR TITLE
fix: add cacao as feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,11 @@ members = [
 full = [
     "client",
     "rpc",
+    "cacao"
 ]
 client = ["dep:relay_client"]
 rpc = ["dep:relay_rpc"]
+cacao = ["dep:relay_rpc"]
 
 [dependencies]
 relay_client = { path = "./relay_client", optional = true }


### PR DESCRIPTION
# Description

Previous commit moves Cacao code to different feature, but is not enabling the feature in Cargo.toml. 
Adding `cacao` feature to Cargo.toml to enable usage of cacao functionality.


## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
