### PR TITLE
feat: batch receive methods for the client

### DIFF
--- a/relay_client/src/http.rs
+++ b/relay_client/src/http.rs
@@ -9,7 +9,7 @@ use {
         auth::ed25519_dalek::Keypair,
         domain::{DecodedClientId, SubscriptionId, Topic},
         jwt::{self, JwtError, VerifyableClaims},
-        rpc::{self, RequestPayload},
+        rpc::{self, Receipt, RequestPayload},
     },
     std::{sync::Arc, time::Duration},
     url::Url,
@@ -243,6 +243,17 @@ impl Client {
     ) -> Response<rpc::BatchFetchMessages> {
         self.request(rpc::BatchFetchMessages {
             topics: topics.into(),
+        })
+        .await
+    }
+
+    /// Acknowledge receipt of messages from a subscribed client.
+    pub async fn batch_receive(
+        &self,
+        receipts: impl Into<Vec<Receipt>>,
+    ) -> Response<rpc::BatchReceiveMessages> {
+        self.request(rpc::BatchReceiveMessages {
+            receipts: receipts.into(),
         })
         .await
     }

--- a/relay_client/src/websocket.rs
+++ b/relay_client/src/websocket.rs
@@ -5,10 +5,12 @@ use {
         domain::{SubscriptionId, Topic},
         rpc::{
             BatchFetchMessages,
+            BatchReceiveMessages,
             BatchSubscribe,
             BatchUnsubscribe,
             FetchMessages,
             Publish,
+            Receipt,
             Subscribe,
             Subscription,
             Unsubscribe,
@@ -224,6 +226,20 @@ impl Client {
     pub fn batch_fetch(&self, topics: impl Into<Vec<Topic>>) -> ResponseFuture<BatchFetchMessages> {
         let (request, response) = create_request(BatchFetchMessages {
             topics: topics.into(),
+        });
+
+        self.request(request);
+
+        response
+    }
+
+    /// Acknowledge receipt of messages from a subscribed client.
+    pub async fn batch_receive(
+        &self,
+        receipts: impl Into<Vec<Receipt>>,
+    ) -> ResponseFuture<BatchReceiveMessages> {
+        let (request, response) = create_request(BatchReceiveMessages {
+            receipts: receipts.into(),
         });
 
         self.request(request);


### PR DESCRIPTION
# Description

This exposes the `irn_batchReceive` RPC method to the clients.

## How Has This Been Tested?

With the relay tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
