### PR TITLE
feat: add tag field to PublishedMessage

### DIFF
--- a/relay_client/src/websocket.rs
+++ b/relay_client/src/websocket.rs
@@ -2,7 +2,7 @@ use {
     self::connection::{connection_event_loop, ConnectionControl},
     crate::{error::Error, ConnectionOptions},
     relay_rpc::{
-        domain::{SubscriptionId, Topic},
+        domain::{MessageId, SubscriptionId, Topic},
         rpc::{
             BatchFetchMessages,
             BatchReceiveMessages,
@@ -74,6 +74,7 @@ mod stream;
 /// The message received from a subscription.
 #[derive(Debug)]
 pub struct PublishedMessage {
+    pub id: MessageId,
     pub topic: Topic,
     pub message: Arc<str>,
     pub tag: u32,
@@ -87,6 +88,7 @@ impl PublishedMessage {
         let now = chrono::Utc::now();
 
         Self {
+            id: request.id(),
             topic: data.topic.clone(),
             message: data.message.clone(),
             tag: data.tag,

--- a/relay_client/src/websocket.rs
+++ b/relay_client/src/websocket.rs
@@ -76,6 +76,7 @@ mod stream;
 pub struct PublishedMessage {
     pub topic: Topic,
     pub message: Arc<str>,
+    pub tag: u32,
     pub published_at: chrono::DateTime<chrono::Utc>,
     pub received_at: chrono::DateTime<chrono::Utc>,
 }
@@ -88,6 +89,7 @@ impl PublishedMessage {
         Self {
             topic: data.topic.clone(),
             message: data.message.clone(),
+            tag: data.tag,
             // TODO: Set proper value once implemented.
             published_at: now,
             received_at: now,

--- a/relay_client/src/websocket/inbound.rs
+++ b/relay_client/src/websocket/inbound.rs
@@ -35,6 +35,10 @@ where
         &self.data
     }
 
+    pub fn id(&self) -> MessageId {
+        self.id
+    }
+
     /// Sends the response back to the Relay. The value is a
     /// `Result<T::Response, T::Error>` (see [`RequestPayload`] trait for
     /// details).


### PR DESCRIPTION
# Description

Some clients will need access to `tag` and 'id` fields from incoming messages.
Passing them throught now.

Resolves #25 

## How Has This Been Tested?

Ran tests.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
