### PR TITLE
feat: expose message_id

### DIFF
--- a/relay_rpc/src/rpc/msg_id.rs
+++ b/relay_rpc/src/rpc/msg_id.rs
@@ -9,18 +9,17 @@ pub trait MsgId {
 
 impl MsgId for rpc::Publish {
     fn msg_id(&self) -> String {
-        let msg_id = Sha256::new()
-            .chain_update(self.message.as_ref().as_bytes())
-            .finalize();
-        format!("{msg_id:x}")
+        get_message_id(&self.message)
     }
 }
 
 impl MsgId for rpc::Subscription {
     fn msg_id(&self) -> String {
-        let msg_id = Sha256::new()
-            .chain_update(self.data.message.as_ref().as_bytes())
-            .finalize();
-        format!("{msg_id:x}")
+        get_message_id(&self.data.message)
     }
+}
+
+pub fn get_message_id(message: &str) -> String {
+    let msg_id = Sha256::new().chain_update(message.as_bytes()).finalize();
+    format!("{msg_id:x}")
 }

--- a/relay_rpc/src/rpc/watch.rs
+++ b/relay_rpc/src/rpc/watch.rs
@@ -240,7 +240,7 @@ mod test {
         // lowercase.
         assert_eq!(
             serde_json::to_string(&claims).unwrap(),
-            r#"{"iss":"did:key:z6Mku3wsRZTAHjr6xrYWVUfyGeNSNz1GJRVfazp3N76AL9gE","aud":"wss://relay.walletconnect.com","sub":"https://example.com","iat":946684800,"exp":32503680000,"act":"irn_watchEvent","typ":"subscriber","whu":"https://example.com","evt":{"status":"accepted","topic":"474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639","message":"test message","publishedAt":946684800,"tag":1100}}"#
+            r#"{"iss":"did:key:z6Mku3wsRZTAHjr6xrYWVUfyGeNSNz1GJRVfazp3N76AL9gE","aud":"wss://relay.walletconnect.com","sub":"https://example.com","iat":946684800,"exp":32503680000,"act":"irn_watchEvent","typ":"subscriber","whu":"https://example.com","evt":{"status":"accepted","topic":"474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639","messageId":"3f0a377ba0a4a460ecb616f6507ce0d8cfa3e704025d4fda3ed0c5ca05468728","message":"test message","publishedAt":946684800,"tag":1100}}"#
         );
 
         // Verify that the claims can be encoded and decoded correctly.

--- a/relay_rpc/src/rpc/watch.rs
+++ b/relay_rpc/src/rpc/watch.rs
@@ -81,7 +81,7 @@ pub struct WatchEventPayload {
     pub status: WatchStatus,
     /// Topic of the message that triggered the watch event.
     pub topic: Topic,
-    /// The published message.
+    /// The published message's ID.
     pub message_id: Arc<str>,
     /// The published message.
     pub message: Arc<str>,

--- a/relay_rpc/src/rpc/watch.rs
+++ b/relay_rpc/src/rpc/watch.rs
@@ -82,6 +82,8 @@ pub struct WatchEventPayload {
     /// Topic of the message that triggered the watch event.
     pub topic: Topic,
     /// The published message.
+    pub message_id: Arc<str>,
+    /// The published message.
     pub message: Arc<str>,
     /// Message publishing timestamp.
     pub published_at: i64,
@@ -121,7 +123,11 @@ pub struct WatchWebhookPayload {
 mod test {
     use {
         super::*,
-        crate::{auth::RELAY_WEBSOCKET_ADDRESS, domain::DecodedClientId},
+        crate::{
+            auth::RELAY_WEBSOCKET_ADDRESS,
+            domain::DecodedClientId,
+            rpc::msg_id::get_message_id,
+        },
         chrono::DateTime,
         ed25519_dalek::Keypair,
     };
@@ -208,6 +214,7 @@ mod test {
         let exp = DateTime::parse_from_rfc3339("3000-01-01T00:00:00Z").unwrap();
         let topic = Topic::from("474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639");
 
+        let message = Arc::from("test message");
         let claims = WatchEventClaims {
             basic: JwtBasicClaims {
                 iss: DecodedClientId::from_key(&key.public_key()).into(),
@@ -222,7 +229,8 @@ mod test {
             evt: WatchEventPayload {
                 status: WatchStatus::Accepted,
                 topic,
-                message: Arc::from("test message"),
+                message_id: get_message_id(&message).into(),
+                message,
                 published_at: iat.timestamp(),
                 tag: 1100,
             },


### PR DESCRIPTION
# Description

Update `WebhookEventPayload` to pass message ID.

Refactor msg_id.rs to allow getting message ID without needing to implement MsgId trait.

Resolves #38

## How Has This Been Tested?

Not tested

## Due Diligence

* [x] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
