### PR TITLE
feat: watch register behalf

### DIFF
--- a/justfile
+++ b/justfile
@@ -66,7 +66,7 @@ fmt:
 
   if command -v cargo-fmt >/dev/null; then
     echo '==> Running rustfmt'
-    cargo +nightly fmt --all -- --check
+    cargo +nightly fmt --all
   else
     echo '==> rustfmt not found in PATH, skipping'
     echo '    ^^^^^^ To install `rustup component add rustfmt`, see https://github.com/rust-lang/rustfmt for details'

--- a/relay_client/src/http.rs
+++ b/relay_client/src/http.rs
@@ -288,10 +288,10 @@ impl Client {
         let status = result.status();
 
         if !status.is_success() {
-            let body = match result.text().await {
-                Ok(body) => body,
-                Err(e) => format!("... error calling result.text(): {e:?}"),
-            };
+            let body = result
+                .text()
+                .await
+                .unwrap_or_else(|e| format!("error reading response body: {e:?}"));
             return Err(HttpClientError::InvalidHttpCode(status, body).into());
         }
 

--- a/relay_client/src/http.rs
+++ b/relay_client/src/http.rs
@@ -36,8 +36,8 @@ pub enum HttpClientError {
     #[error("Invalid response")]
     InvalidResponse,
 
-    #[error("Invalid HTTP status: {0}, body: {1}")]
-    InvalidHttpCode(StatusCode, String),
+    #[error("Invalid HTTP status: {0}, body: {1:?}")]
+    InvalidHttpCode(StatusCode, reqwest::Result<String>),
 
     #[error("JWT error: {0}")]
     Jwt(#[from] JwtError),
@@ -288,10 +288,7 @@ impl Client {
         let status = result.status();
 
         if !status.is_success() {
-            let body = result
-                .text()
-                .await
-                .unwrap_or_else(|e| format!("error reading response body: {e:?}"));
+            let body = result.text().await;
             return Err(HttpClientError::InvalidHttpCode(status, body).into());
         }
 

--- a/relay_client/src/http.rs
+++ b/relay_client/src/http.rs
@@ -187,6 +187,14 @@ impl Client {
         self.request(payload).await
     }
 
+    /// Registers a webhook to watch messages on behalf of another client.
+    pub async fn watch_register_behalf(
+        &self,
+        register_auth: String,
+    ) -> Response<rpc::WatchRegister> {
+        self.request(rpc::WatchRegister { register_auth }).await
+    }
+
     /// Unregisters a webhook to watch messages.
     pub async fn watch_unregister(
         &self,

--- a/relay_rpc/src/rpc/msg_id.rs
+++ b/relay_rpc/src/rpc/msg_id.rs
@@ -9,18 +9,17 @@ pub trait MsgId {
 
 impl MsgId for rpc::Publish {
     fn msg_id(&self) -> String {
-        let msg_id = Sha256::new()
-            .chain_update(self.message.as_ref().as_bytes())
-            .finalize();
-        format!("{msg_id:x}")
+        get_message_id(&self.message)
     }
 }
 
 impl MsgId for rpc::Subscription {
     fn msg_id(&self) -> String {
-        let msg_id = Sha256::new()
-            .chain_update(self.data.message.as_ref().as_bytes())
-            .finalize();
-        format!("{msg_id:x}")
+        get_message_id(&self.data.message)
     }
+}
+
+pub fn get_message_id(message: &str) -> String {
+    let msg_id = Sha256::new().chain_update(message.as_bytes()).finalize();
+    format!("{msg_id:x}")
 }

--- a/relay_rpc/src/rpc/watch.rs
+++ b/relay_rpc/src/rpc/watch.rs
@@ -81,8 +81,6 @@ pub struct WatchEventPayload {
     pub status: WatchStatus,
     /// Topic of the message that triggered the watch event.
     pub topic: Topic,
-    /// The published message's ID.
-    pub message_id: Arc<str>,
     /// The published message.
     pub message: Arc<str>,
     /// Message publishing timestamp.
@@ -123,11 +121,7 @@ pub struct WatchWebhookPayload {
 mod test {
     use {
         super::*,
-        crate::{
-            auth::RELAY_WEBSOCKET_ADDRESS,
-            domain::DecodedClientId,
-            rpc::msg_id::get_message_id,
-        },
+        crate::{auth::RELAY_WEBSOCKET_ADDRESS, domain::DecodedClientId},
         chrono::DateTime,
         ed25519_dalek::Keypair,
     };
@@ -214,7 +208,6 @@ mod test {
         let exp = DateTime::parse_from_rfc3339("3000-01-01T00:00:00Z").unwrap();
         let topic = Topic::from("474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639");
 
-        let message = Arc::from("test message");
         let claims = WatchEventClaims {
             basic: JwtBasicClaims {
                 iss: DecodedClientId::from_key(&key.public_key()).into(),
@@ -229,8 +222,7 @@ mod test {
             evt: WatchEventPayload {
                 status: WatchStatus::Accepted,
                 topic,
-                message_id: get_message_id(&message).into(),
-                message,
+                message: Arc::from("test message"),
                 published_at: iat.timestamp(),
                 tag: 1100,
             },
@@ -240,7 +232,7 @@ mod test {
         // lowercase.
         assert_eq!(
             serde_json::to_string(&claims).unwrap(),
-            r#"{"iss":"did:key:z6Mku3wsRZTAHjr6xrYWVUfyGeNSNz1GJRVfazp3N76AL9gE","aud":"wss://relay.walletconnect.com","sub":"https://example.com","iat":946684800,"exp":32503680000,"act":"irn_watchEvent","typ":"subscriber","whu":"https://example.com","evt":{"status":"accepted","topic":"474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639","messageId":"3f0a377ba0a4a460ecb616f6507ce0d8cfa3e704025d4fda3ed0c5ca05468728","message":"test message","publishedAt":946684800,"tag":1100}}"#
+            r#"{"iss":"did:key:z6Mku3wsRZTAHjr6xrYWVUfyGeNSNz1GJRVfazp3N76AL9gE","aud":"wss://relay.walletconnect.com","sub":"https://example.com","iat":946684800,"exp":32503680000,"act":"irn_watchEvent","typ":"subscriber","whu":"https://example.com","evt":{"status":"accepted","topic":"474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639","message":"test message","publishedAt":946684800,"tag":1100}}"#
         );
 
         // Verify that the claims can be encoded and decoded correctly.

--- a/relay_rpc/src/rpc/watch.rs
+++ b/relay_rpc/src/rpc/watch.rs
@@ -240,7 +240,7 @@ mod test {
         // lowercase.
         assert_eq!(
             serde_json::to_string(&claims).unwrap(),
-            r#"{"iss":"did:key:z6Mku3wsRZTAHjr6xrYWVUfyGeNSNz1GJRVfazp3N76AL9gE","aud":"wss://relay.walletconnect.com","sub":"https://example.com","iat":946684800,"exp":32503680000,"act":"irn_watchEvent","typ":"subscriber","whu":"https://example.com","evt":{"status":"accepted","topic":"474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639","message":"test message","publishedAt":946684800,"tag":1100}}"#
+            r#"{"iss":"did:key:z6Mku3wsRZTAHjr6xrYWVUfyGeNSNz1GJRVfazp3N76AL9gE","aud":"wss://relay.walletconnect.com","sub":"https://example.com","iat":946684800,"exp":32503680000,"act":"irn_watchEvent","typ":"subscriber","whu":"https://example.com","evt":{"status":"accepted","topic":"474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639","messageId":"3f0a377ba0a4a460ecb616f6507ce0d8cfa3e704025d4fda3ed0c5ca05468728","message":"test message","publishedAt":946684800,"tag":1100}}"#
         );
 
         // Verify that the claims can be encoded and decoded correctly.

--- a/relay_rpc/src/rpc/watch.rs
+++ b/relay_rpc/src/rpc/watch.rs
@@ -81,7 +81,7 @@ pub struct WatchEventPayload {
     pub status: WatchStatus,
     /// Topic of the message that triggered the watch event.
     pub topic: Topic,
-    /// The published message.
+    /// The published message's ID.
     pub message_id: Arc<str>,
     /// The published message.
     pub message: Arc<str>,

--- a/relay_rpc/src/rpc/watch.rs
+++ b/relay_rpc/src/rpc/watch.rs
@@ -82,6 +82,8 @@ pub struct WatchEventPayload {
     /// Topic of the message that triggered the watch event.
     pub topic: Topic,
     /// The published message.
+    pub message_id: Arc<str>,
+    /// The published message.
     pub message: Arc<str>,
     /// Message publishing timestamp.
     pub published_at: i64,
@@ -121,7 +123,11 @@ pub struct WatchWebhookPayload {
 mod test {
     use {
         super::*,
-        crate::{auth::RELAY_WEBSOCKET_ADDRESS, domain::DecodedClientId},
+        crate::{
+            auth::RELAY_WEBSOCKET_ADDRESS,
+            domain::DecodedClientId,
+            rpc::msg_id::get_message_id,
+        },
         chrono::DateTime,
         ed25519_dalek::Keypair,
     };
@@ -208,6 +214,7 @@ mod test {
         let exp = DateTime::parse_from_rfc3339("3000-01-01T00:00:00Z").unwrap();
         let topic = Topic::from("474e88153f4db893de42c35e1891dc0e37a02e11961385de0475460fb48b8639");
 
+        let message = Arc::from("test message");
         let claims = WatchEventClaims {
             basic: JwtBasicClaims {
                 iss: DecodedClientId::from_key(&key.public_key()).into(),
@@ -222,7 +229,8 @@ mod test {
             evt: WatchEventPayload {
                 status: WatchStatus::Accepted,
                 topic,
-                message: Arc::from("test message"),
+                message_id: get_message_id(&message).into(),
+                message,
                 published_at: iat.timestamp(),
                 tag: 1100,
             },


### PR DESCRIPTION
# Description

- Add `watch_register_behalf()` function which allows passing-through `register_auth` payload from client
- Non-successful RPC requests will include the error body
- `just fmt` will auto-format instead of just `--check`
- `get_message_id()` refactor left-over from https://github.com/WalletConnect/WalletConnectRust/pull/39

Resolves #40

## How Has This Been Tested?

With archive refactor

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
