### PR TITLE
feat: Update cacao identity resolution

### DIFF
--- a/relay_rpc/src/auth/cacao/payload.rs
+++ b/relay_rpc/src/auth/cacao/payload.rs
@@ -74,6 +74,11 @@ impl Payload {
     }
 
     pub fn identity_key(&self) -> Result<String, CacaoError> {
+        self.identity_key_from_audience()
+            .or_else(|_| self.identity_key_from_resources())
+    }
+
+    fn identity_key_from_resources(&self) -> Result<String, CacaoError> {
         let resources = self
             .resources
             .as_ref()
@@ -81,6 +86,12 @@ impl Payload {
         let did_key = resources.first().ok_or(CacaoError::PayloadIdentityKey)?;
 
         extract_did_data(did_key, DID_METHOD_KEY)
+            .map(|data| data.to_string())
+            .map_err(|_| CacaoError::PayloadIdentityKey)
+    }
+
+    fn identity_key_from_audience(&self) -> Result<String, CacaoError> {
+        extract_did_data(&self.aud, DID_METHOD_KEY)
             .map(|data| data.to_string())
             .map_err(|_| CacaoError::PayloadIdentityKey)
     }

--- a/relay_rpc/src/auth/cacao/tests.rs
+++ b/relay_rpc/src/auth/cacao/tests.rs
@@ -1,81 +1,102 @@
 use crate::auth::cacao::Cacao;
 
+/// Test that we can verify a deprecated Cacao.
+#[test]
+fn cacao_verify_success() {
+    let cacao_serialized = r#"{
+      "h": {
+        "t": "eip4361"
+      },
+      "p": {
+        "iss": "did:pkh:eip155:1:0xB1bad80be351061Db2F726D2dDe28E0Ebbb88D30",
+        "domain": "keys.walletconnect.com",
+        "aud": "https://keys.walletconnect.com",
+        "version": "1",
+        "nonce": "2c586f5025cb20094329ccd83684e2b192bebb2a3f83fc91b0b27aa817fd24de",
+        "iat": "2023-05-17T14:22:32+02:00",
+        "resources": [
+          "did:key:z6MkhoV7JnKEFgwai4R1ui14xcPDnqVFZ3a9dUNM3fE3z3Nf"
+        ]
+      },
+      "s": {
+        "t": "eip191",
+        "s": "0x991f379195564ba1d131c53cc9b3cf13c03e3a8111f502fd40ca12e1d04d98ea58531295c48f852c9c35a938c778f52a2c994f109fc0e94cc4e16f62d41d54371c"
+      }
+    }"#;
+    let cacao: Cacao = serde_json::from_str(cacao_serialized).unwrap();
+    let result = cacao.verify();
+    assert!(result.is_ok());
+    assert!(result.map_err(|_| false).unwrap());
+
+    let identity_key = cacao.p.identity_key();
+    assert!(identity_key.is_ok());
+    assert_eq!(
+        identity_key.unwrap(),
+        "z6MkhoV7JnKEFgwai4R1ui14xcPDnqVFZ3a9dUNM3fE3z3Nf"
+    )
+}
+
+/// Test that we can verify a updated Cacao.
+#[test]
+fn cacao_verify_success_identity_in_audience() {
+    let cacao_serialized = r#"{
+        "h": {
+            "t": "eip4361"
+        },
+        "p": {
+            "iss": "did:pkh:eip155:1:0xdFe7d0E324ed017a74aE311E9236E6CaDB24176b",
+            "domain": "com.walletconnect.sample.web3inbox",
+            "aud": "did:key:z6MkvjNoiz9AXGH1igzrtB54US5hE9bZPQm1ryKGkCLwWht7",
+            "version": "1",
+            "nonce": "6c9435d868ce15e0a1b0987a61a975e8c0edda17054840548dabf0a3c55cf5e4",
+            "iat": "2023-09-07T11:04:23+02:00",
+            "statement": "I further authorize this DAPP to send and receive messages on my behalf for this domain and manage my identity at identity.walletconnect.com.",
+            "resources": [
+                "identity.walletconnect.com"
+            ]
+        },
+        "s": {
+            "t": "eip191",
+            "s": "0x18b8dd2595930bd4bcd8066ad9fca5c54aaab20d2ec1cf46ff90baa5a91acad80f064a2f533d9dfc75928958a1da8e4f6755e14cab325a40a3a51e4bd6f2a1c91b"
+        }
+    }"#;
+    let cacao: Cacao = serde_json::from_str(cacao_serialized).unwrap();
+    let result = cacao.verify();
+    assert!(result.is_ok());
+    assert!(result.map_err(|_| false).unwrap());
+
+    let identity_key = cacao.p.identity_key();
+    assert!(identity_key.is_ok());
+    assert_eq!(
+        identity_key.unwrap(),
+        "z6MkvjNoiz9AXGH1igzrtB54US5hE9bZPQm1ryKGkCLwWht7"
+    )
+}
+
 /// Test that we can verify a Cacao
 #[test]
-fn verify_success() {
+fn cacao_verify_failure() {
     let cacao_serialized = r#"{
       "h": {
         "t": "eip4361"
       },
       "p": {
-        "iss": "did:pkh:eip155:1:0x262f4f5DC82ad9b803680F07Da7d901D4F71d8D1",
-        "domain": "http://10.0.2.2:8080",
-        "aud": "http://10.0.2.2:8080",
+        "iss": "did:pkh:eip155:1:0xF5dA9A1Aa622903ae73f5eFE46485531913202AF",
+        "domain": "keys.walletconnect.com",
+        "aud": "https://keys.walletconnect.com",
         "version": "1",
-        "nonce": "[B@c3772c7",
-        "iat": "2023-01-17T12:15:05+01:00",
+        "nonce": "0d98d4e5d8c19d4cff09cd25f1863bca650d2b4009bd62f04dff7171438c4773",
+        "iat": "2023-05-17T14:14:24+02:00",
         "resources": [
-          "did:key:z6MkkG9nM8ksS37sq5mgeoCn5kihLkWANcm9pza5WTkq3tWZ"
+          "did:key:z6MkgzojB48jpTcLTatSCRHNpoMRvQbz8r13UJ1KyteHjEu9"
         ]
       },
       "s": {
         "t": "eip191",
-        "s": "0xf2f0e5dc8875ef1e3d40472078b06ebe4af5fc832e464338996fb0d3134cde7613bc36416519e8dd8959655f0e89c6b7a9de55f7c95f43e8d2240f89939ed7171c"
+        "s": "0x726caf0b066fd857889fa73a8b04cbe249161c37a9342854ec92258a85a91ca5720d6d61afe45c7a54f42373ab1c90d888257637a938af5d9f242adad43b204d1b"
       }
-    } "#;
-    let cacao: Cacao = serde_json::from_str(cacao_serialized).unwrap();
-    println!("{}", cacao.siwe_message().unwrap());
-    let result = cacao.verify();
-    assert!(result.is_ok());
-    assert!(result.map_err(|_| false).unwrap());
-
-    let identity_key = cacao.p.identity_key();
-    assert!(identity_key.is_ok());
-}
-
-/// Test that we can verify a Cacao with a statement
-#[test]
-fn verify_success_statement() {
-    let cacao_serialized = r#"{
-      "h": {
-        "t": "eip4361"
-      },
-      "p": {
-        "iss": "did:pkh:eip155:1:0x262f4f5DC82ad9b803680F07Da7d901D4F71d8D1",
-        "domain": "http://10.0.2.2:8080",
-        "aud": "http://10.0.2.2:8080",
-        "statement": "Test statement",
-        "version": "1",
-        "nonce": "[B@c3772c7",
-        "iat": "2023-01-17T12:15:05+01:00",
-        "resources": [
-          "did:key:z6MkkG9nM8ksS37sq5mgeoCn5kihLkWANcm9pza5WTkq3tWZ"
-        ]
-      },
-      "s": {
-        "t": "eip191",
-        "s": "0xafedb7505846dc691a4f3f70266624a91a232d68ec61454f4426e016bcb0483773296097687429c47af82b5bf16324ec4ede13e67aee5b4597c9d34b3af0e3681c"
-      }
-    } "#;
-    let cacao: Cacao = serde_json::from_str(cacao_serialized).unwrap();
-    println!("{}", cacao.siwe_message().unwrap());
-    let result = cacao.verify();
-    assert!(result.is_ok());
-    assert!(result.map_err(|_| false).unwrap());
-
-    let identity_key = cacao.p.identity_key();
-    assert!(identity_key.is_ok());
-}
-
-/// Test that we can verify a Cacao with uppercase address
-#[test]
-fn without_lowercase_address_verify_success() {
-    let cacao_serialized = r#"{"h":{"t":"eip4361"},"p":{"iss":"did:pkh:eip155:1:0xbD4D1935165012e7D29919dB8717A5e670a1a5b1","domain":"https://staging.keys.walletconnect.com","aud":"https://staging.keys.walletconnect.com","version":"1","nonce":"07487c09be5535dcbc341d8e35e5c9b4d3539a802089c42c5b1172dd9ed63c64","iat":"2023-01-25T15:08:36.846Z","statement":"Test","resources":["did:key:451cf9b97c64fcca05fbb0d4c40b886c94133653df5a2b6bd97bd29a0bbcdb37"]},"s":{"t":"eip191","s":"0x8496ad1dd1ddd5cb78ac26b62a6bd1c6cfff703ea3b11a9da29cfca112357ace75cac8ee28d114f9e166a6935ee9ed83151819a9e0ee738a0547116b1d978e351b"}}"#;
+    }"#;
     let cacao: Cacao = serde_json::from_str(cacao_serialized).unwrap();
     let result = cacao.verify();
-    assert!(result.is_ok());
-    assert!(result.map_err(|_| false).unwrap());
-
-    let identity_key = cacao.p.identity_key();
-    assert!(identity_key.is_ok());
+    assert!(result.is_err());
 }


### PR DESCRIPTION
# Description

Required by https://github.com/WalletConnect/walletconnect-specs/pull/139
The identity key will no longer be in Cacao resources but in the audience. In order to avoid breaking changes we accept both versions. If Identity Key is present in both resources and audience the latter is taken. 

Resolves #45  

## How Has This Been Tested?

Unit tests supported by data generated by Kotlin SDK

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
