### PR TITLE
fix: RUSTSEC-2023-0065

### DIFF
--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { version = "0.11", features = ["json"] }
 
 # WebSocket client dependencies.
 tokio = { version = "1.22", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }
-tokio-tungstenite = "0.18"
+tokio-tungstenite = "0.20"
 futures-channel = "0.3"
 tokio-stream = "0.1"
 tokio-util = "0.7"


### PR DESCRIPTION
# Description

Fixing some Dependabot and `cargo audit` errors in Notify Server, need to bump the version in this repo or is incompatible with the version I want to use in Notify Server.

Good news is WalletConnectRust has zero security warnings after this PR.

## How Has This Been Tested?

https://github.com/WalletConnect/notify-server/pull/232

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
