### PR TITLE
fix: only check PR title

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,18 +78,3 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           locale: "US"
-
-  cocogitto:
-    name: cocogitto
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: "Conventional commit check"
-        uses: cocogitto/cocogitto-action@v3
-        with:
-          check: true
-          check-latest-tag-only: true

--- a/.github/workflows/event_pr.yaml
+++ b/.github/workflows/event_pr.yaml
@@ -1,0 +1,34 @@
+name: ⚡ Pull-Request
+run-name: 'PR / ${{ github.event.pull_request.title }}'
+
+on:
+  pull_request:
+    types:
+      - opened        # A pull request was created.
+      - reopened      # A closed pull request was reopened.
+      - edited        # A pull request's title, body, or labels are edited.
+      - synchronize   # A pull request's branch was synchronized with its base branch.
+      - unlocked      # Conversation on a pull request was unlocked.
+
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+  issues: read
+  pull-requests: write
+
+jobs:
+  check_pr:
+    name: Check PR
+    runs-on:
+      group: ${{ vars.RUN_GROUP }}
+    permissions:
+      statuses: write
+    steps:
+      - name: Check PR Title
+        uses: aslafy-z/conventional-pr-title-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

Only checks the PR title, rather than the commits inside, because this is squashed

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
