### PR TITLE
chore: refactor magic strings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rpc = ["dep:relay_rpc"]
 
 [dependencies]
 relay_client = { path = "./relay_client", optional = true }
-relay_rpc = { path = "./relay_rpc", optional = true, features = ["cacao"] }
+relay_rpc = { path = "./relay_rpc", optional = true }
 
 [dev-dependencies]
 anyhow = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ rpc = ["dep:relay_rpc"]
 
 [dependencies]
 relay_client = { path = "./relay_client", optional = true }
-relay_rpc = { path = "./relay_rpc", optional = true }
+relay_rpc = { path = "./relay_rpc", optional = true, features = ["cacao"] }
 
 [dev-dependencies]
 anyhow = "1"

--- a/relay_rpc/src/auth/cacao/header.rs
+++ b/relay_rpc/src/auth/cacao/header.rs
@@ -3,6 +3,8 @@ use {
     serde::{Deserialize, Serialize},
 };
 
+pub const EIP4361: &str = "eip4361";
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub struct Header {
     pub t: String,
@@ -11,7 +13,7 @@ pub struct Header {
 impl Header {
     pub fn validate(&self) -> Result<(), CacaoError> {
         match self.t.as_str() {
-            "eip4361" => Ok(()),
+            EIP4361 => Ok(()),
             _ => Err(CacaoError::Header),
         }
     }

--- a/relay_rpc/src/auth/cacao/signature.rs
+++ b/relay_rpc/src/auth/cacao/signature.rs
@@ -3,6 +3,8 @@ use {
     serde::{Deserialize, Serialize},
 };
 
+pub const EIP191: &str = "eip191";
+
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub struct Signature {
     pub t: String,
@@ -12,7 +14,7 @@ pub struct Signature {
 impl Signature {
     pub fn verify(&self, cacao: &Cacao) -> Result<bool, CacaoError> {
         match self.t.as_str() {
-            "eip191" => Eip191.verify(&cacao.s.s, &cacao.p.address()?, &cacao.siwe_message()?),
+            EIP191 => Eip191.verify(&cacao.s.s, &cacao.p.address()?, &cacao.siwe_message()?),
             // "eip1271" => Eip1271.verify(), TODO: How to accces our RPC?
             _ => Err(CacaoError::UnsupportedSignature),
         }


### PR DESCRIPTION
# Description

- Refactors magic strings so they can be used in Notify Server test cases.
- Fixes that CI doesn't build the cacao feature.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
