### PR TITLE
fix: allow cloning PublishedMessage

### DIFF
--- a/relay_client/src/websocket.rs
+++ b/relay_client/src/websocket.rs
@@ -72,7 +72,7 @@ mod outbound;
 mod stream;
 
 /// The message received from a subscription.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct PublishedMessage {
     pub message_id: MessageId,
     pub subscription_id: SubscriptionId,


### PR DESCRIPTION
# Description

Allows cloning the `PublishedMessage` so that it can be used inside of a `broadcast::Receiver<T>`

Required for [this PR](https://github.com/WalletConnect/notify-server/pull/264)

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
