### PR TITLE
fix: update events to array to match specs

### DIFF
--- a/examples/webhook.rs
+++ b/examples/webhook.rs
@@ -211,7 +211,8 @@ async fn main() -> anyhow::Result<()> {
     println!("[subscriber] received message: {}", message.message);
 
     let pub_data = server.recv().await;
-    let decoded = rpc::WatchEventClaims::try_from_str(&pub_data.payload.event_auth).unwrap();
+    let decoded =
+        rpc::WatchEventClaims::try_from_str(pub_data.payload.event_auth.first().unwrap()).unwrap();
     let decoded_json = serde_json::to_string_pretty(&decoded).unwrap();
     println!(
         "[webhook] publisher: url={} data={}",
@@ -219,7 +220,8 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let sub_data = server.recv().await;
-    let decoded = rpc::WatchEventClaims::try_from_str(&sub_data.payload.event_auth).unwrap();
+    let decoded =
+        rpc::WatchEventClaims::try_from_str(sub_data.payload.event_auth.first().unwrap()).unwrap();
     let decoded_json = serde_json::to_string_pretty(&decoded).unwrap();
     println!(
         "[webhook] subscriber: url={} data={}",

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -4,19 +4,38 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
-cacao = ["dep:k256", "dep:sha3"]
+cacao = [
+    "dep:k256",
+    "dep:sha3",
+    "dep:alloy-providers",
+    "dep:alloy-transport",
+    "dep:alloy-transport-http",
+    "dep:alloy-rpc-types",
+    "dep:alloy-json-rpc",
+    "dep:alloy-json-abi",
+    "dep:alloy-sol-types",
+    "dep:alloy-primitives",
+]
 
 [dependencies]
 bs58 = "0.4"
 data-encoding = "2.3"
-derive_more = { version = "0.99", default-features = false, features = ["display", "from", "as_ref", "as_mut"] }
+derive_more = { version = "0.99", default-features = false, features = [
+    "display",
+    "from",
+    "as_ref",
+    "as_mut",
+] }
 serde = { version = "1.0", features = ["derive", "rc"] }
 serde-aux = { version = "4.1", default-features = false }
 serde_json = "1.0"
 thiserror = "1.0"
 ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "7529d65" }
 rand = "0.7"
-chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+chrono = { version = "0.4", default-features = false, features = [
+    "std",
+    "clock",
+] }
 regex = "1.7"
 once_cell = "1.16"
 jsonwebtoken = "8.1"
@@ -25,14 +44,14 @@ sha3 = { version = "0.10", optional = true }
 sha2 = { version = "0.10.6" }
 reqwest = { version = "0.11", features = ["default-tls"] }
 url = "2"
-alloy-providers = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1" }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1" }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1" }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1" }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1" }
-alloy-json-abi = "0.6.2"
-alloy-sol-types = "0.6.2"
-alloy-primitives = "0.6.2"
+alloy-providers = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
+alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
+alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
+alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
+alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
+alloy-json-abi = { version = "0.6.2", optional = true }
+alloy-sol-types = { version = "0.6.2", optional = true }
+alloy-primitives = { version = "0.6.2", optional = true }
 
 [dev-dependencies]
 tokio = { version = "1.35.1", features = ["test-util", "macros"] }

--- a/relay_rpc/src/rpc/watch.rs
+++ b/relay_rpc/src/rpc/watch.rs
@@ -116,7 +116,7 @@ impl VerifyableClaims for WatchEventClaims {
 #[serde(rename_all = "camelCase")]
 pub struct WatchWebhookPayload {
     /// JWT with [`WatchEventClaims`] payload.
-    pub event_auth: String,
+    pub event_auth: Vec<String>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# Description

Updates the format to match [the specs](https://github.com/WalletConnect/walletconnect-specs/pull/127/files#r1468254981).

Also makes alloy dependencies optional (dependent on cacao feature) to avoid dependency conflicts with relay.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
