### PR TITLE
fix: do not lowercase caip_10 adresses

### DIFF
--- a/relay_rpc/src/auth/cacao/payload.rs
+++ b/relay_rpc/src/auth/cacao/payload.rs
@@ -69,8 +69,7 @@ impl Payload {
             self.chain_id_reference()?,
             Self::ISS_DELIMITER,
             self.address()?
-        )
-        .to_lowercase())
+        ))
     }
 
     pub fn identity_key(&self) -> Result<String, CacaoError> {


### PR DESCRIPTION
# Description

When converging Keys Server to this module we overlooked difference in this function

Resolves # (issue)

## How Has This Been Tested?

Was tested previously. Caused regression

We need to make sure if Notify Server doesn't depend on it

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
