### PR TITLE
fix: loosen version constraints

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,11 +55,25 @@ jobs:
           profile: default
           override: true
 
+      # Install nightly which is required for supporting `-Z minimal-versions`
+      # https://github.com/rust-lang/cargo/issues/5657
+      - name: "Install Rust nightly"
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+
       - uses: Swatinem/rust-cache@v2
 
       - uses: taiki-e/install-action@v1
         with:
           tool: nextest
+
+      # Install the minimal versions this package says it supports
+      # https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277
+      # https://github.com/rust-lang/cargo/issues/5657
+      - name: "Install minimal package versions"
+        run: cargo +nightly -Z minimal-versions update
 
       - name: "Cargo ${{ matrix.cargo.name }}"
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ relay_rpc = { path = "./relay_rpc", optional = true }
 [dev-dependencies]
 anyhow = "1"
 structopt = { version = "0.3", default-features = false }
-tokio = { version = "1.22", features = ["full"] }
-url = "2.3"
+tokio = { version = "1", features = ["full"] }
+url = "2"
 warp = { version = "0.3", default-features = false }
-serde_json = "1.0"
+serde_json = "1"
 
 [[example]]
 name = "websocket_client"

--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -10,20 +10,20 @@ rustls = ["tokio-tungstenite/rustls-tls-native-roots"]
 [dependencies]
 relay_rpc = { path = "../relay_rpc" }
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
-thiserror = "1.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
+thiserror = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_qs = "0.10"
 pin-project = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }
-url = "2.3"
+url = "2"
 http = "0.2"
 
 # HTTP client dependencies.
 reqwest = { version = "0.11", features = ["json"] }
 
 # WebSocket client dependencies.
-tokio = { version = "1.22", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }
 tokio-tungstenite = "0.20"
 futures-channel = "0.3"
 tokio-stream = "0.1"

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -26,22 +26,22 @@ derive_more = { version = "0.99", default-features = false, features = [
     "as_ref",
     "as_mut",
 ] }
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde-aux = { version = "4.1", default-features = false }
-serde_json = "1.0"
-thiserror = "1.0"
+serde = { version = "1", features = ["derive", "rc"] }
+serde-aux = { version = "4", default-features = false }
+serde_json = "1"
+thiserror = "1"
 ed25519-dalek = { git = "https://github.com/dalek-cryptography/ed25519-dalek.git", rev = "7529d65" }
 rand = "0.7"
 chrono = { version = "0.4", default-features = false, features = [
     "std",
     "clock",
 ] }
-regex = "1.7"
-once_cell = "1.16"
-jsonwebtoken = "8.1"
+regex = "1"
+once_cell = "1"
+jsonwebtoken = "8"
 k256 = { version = "0.13", optional = true }
 sha3 = { version = "0.10", optional = true }
-sha2 = { version = "0.10.6" }
+sha2 = { version = "0.10" }
 reqwest = { version = "0.11", features = ["default-tls"] }
 url = "2"
 alloy-providers = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
@@ -49,9 +49,9 @@ alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e
 alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
 alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
 alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
-alloy-json-abi = { version = "0.6.2", optional = true }
-alloy-sol-types = { version = "0.6.2", optional = true }
-alloy-primitives = { version = "0.6.2", optional = true }
+alloy-json-abi = { version = "0.6", optional = true }
+alloy-sol-types = { version = "0.6", optional = true }
+alloy-primitives = { version = "0.6", optional = true }
 
 [dev-dependencies]
-tokio = { version = "1.35.1", features = ["test-util", "macros"] }
+tokio = { version = "1", features = ["test-util", "macros"] }

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -38,7 +38,7 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 regex = "1"
 once_cell = "1"
-jsonwebtoken = "8"
+jsonwebtoken = "8.1"
 k256 = { version = "0.13", optional = true }
 sha3 = { version = "0.10", optional = true }
 sha2 = { version = "0.10" }


### PR DESCRIPTION
# Description

Removes specific version req's. We should be as permissive as possible, letting the downstream app customize the versions. If this library requires a specific minor version or patch, then we can use `^`, `~` or `*` as appropriate

Resolves  #44

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
