### PR TITLE
feat: error handling overhaul

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ url = "2.3"
 warp = { version = "0.3", default-features = false }
 serde_json = "1.0"
 rand = "0.8.5"
+futures-util = "0.3"
+once_cell = "1.19"
 
 [[example]]
 name = "websocket_client"

--- a/examples/websocket_client.rs
+++ b/examples/websocket_client.rs
@@ -1,6 +1,6 @@
 use {
     relay_client::{
-        error::Error,
+        error::ClientError,
         websocket::{Client, CloseFrame, ConnectionHandler, PublishedMessage},
         ConnectionOptions,
     },
@@ -49,11 +49,11 @@ impl ConnectionHandler for Handler {
         );
     }
 
-    fn inbound_error(&mut self, error: Error) {
+    fn inbound_error(&mut self, error: ClientError) {
         println!("[{}] inbound error: {error}", self.name);
     }
 
-    fn outbound_error(&mut self, error: Error) {
+    fn outbound_error(&mut self, error: ClientError) {
         println!("[{}] outbound error: {error}", self.name);
     }
 }

--- a/relay_client/src/error.rs
+++ b/relay_client/src/error.rs
@@ -75,7 +75,7 @@ impl From<rpc::ErrorData> for ClientError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum Error<T: ServiceError> {
+pub enum Error<T> {
     /// Client errors encountered while performing the request.
     #[error(transparent)]
     Client(ClientError),

--- a/relay_client/src/error.rs
+++ b/relay_client/src/error.rs
@@ -1,3 +1,5 @@
+use relay_rpc::rpc::{self, error::ServiceError};
+
 pub type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 /// Errors generated while parsing
@@ -23,7 +25,7 @@ pub enum RequestBuildError {
 
 /// Possible Relay client errors.
 #[derive(Debug, thiserror::Error)]
-pub enum Error {
+pub enum ClientError {
     #[error("Failed to build connection request: {0}")]
     RequestBuilder(#[from] RequestBuildError),
 
@@ -42,15 +44,69 @@ pub enum Error {
     #[error("Invalid response ID")]
     InvalidResponseId,
 
+    #[error("Invalid error response")]
+    InvalidErrorResponse,
+
     #[error("Serialization failed: {0}")]
     Serialization(serde_json::Error),
 
     #[error("Deserialization failed: {0}")]
     Deserialization(serde_json::Error),
 
-    #[error("RPC error ({code}): {message}")]
-    Rpc { code: i32, message: String },
+    #[error("RPC error: code={code} data={data:?} message={message}")]
+    Rpc {
+        code: i32,
+        message: String,
+        data: Option<String>,
+    },
 
     #[error("Invalid request type")]
     InvalidRequestType,
+}
+
+impl From<rpc::ErrorData> for ClientError {
+    fn from(err: rpc::ErrorData) -> Self {
+        Self::Rpc {
+            code: err.code,
+            message: err.message,
+            data: err.data,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error<T: ServiceError> {
+    /// Client errors encountered while performing the request.
+    #[error(transparent)]
+    Client(ClientError),
+
+    /// Error response received from the relay.
+    #[error(transparent)]
+    Response(#[from] rpc::Error<T>),
+}
+
+impl<T: ServiceError> From<ClientError> for Error<T> {
+    fn from(err: ClientError) -> Self {
+        match err {
+            ClientError::Rpc {
+                code,
+                message,
+                data,
+            } => {
+                let err = rpc::ErrorData {
+                    code,
+                    message,
+                    data,
+                };
+
+                match rpc::Error::try_from(err) {
+                    Ok(err) => Error::Response(err),
+
+                    Err(_) => Error::Client(ClientError::InvalidErrorResponse),
+                }
+            }
+
+            _ => Error::Client(err),
+        }
+    }
 }

--- a/relay_client/src/lib.rs
+++ b/relay_client/src/lib.rs
@@ -1,5 +1,5 @@
 use {
-    crate::error::{Error, RequestBuildError},
+    crate::error::{ClientError, RequestBuildError},
     ::http::HeaderMap,
     relay_rpc::{
         auth::{SerializedAuthToken, RELAY_WEBSOCKET_ADDRESS},

--- a/relay_client/src/websocket/connection.rs
+++ b/relay_client/src/websocket/connection.rs
@@ -8,7 +8,7 @@ use {
     },
     crate::{
         websocket::{stream::StreamEvent, PublishedMessage},
-        Error,
+        ClientError,
         HttpRequest,
     },
     futures_util::{stream::FusedStream, Stream, StreamExt},
@@ -22,11 +22,11 @@ use {
 pub(super) enum ConnectionControl {
     Connect {
         request: HttpRequest<()>,
-        tx: oneshot::Sender<Result<(), Error>>,
+        tx: oneshot::Sender<Result<(), ClientError>>,
     },
 
     Disconnect {
-        tx: oneshot::Sender<Result<(), Error>>,
+        tx: oneshot::Sender<Result<(), ClientError>>,
     },
 
     OutboundRequest(OutboundRequest),
@@ -107,7 +107,7 @@ impl Connection {
         Self { stream: None }
     }
 
-    async fn connect(&mut self, request: HttpRequest<()>) -> Result<(), Error> {
+    async fn connect(&mut self, request: HttpRequest<()>) -> Result<(), ClientError> {
         if let Some(mut stream) = self.stream.take() {
             stream.close(None).await?;
         }
@@ -117,7 +117,7 @@ impl Connection {
         Ok(())
     }
 
-    async fn disconnect(&mut self) -> Result<(), Error> {
+    async fn disconnect(&mut self) -> Result<(), ClientError> {
         let stream = self.stream.take();
 
         match stream {

--- a/relay_client/src/websocket/fetch.rs
+++ b/relay_client/src/websocket/fetch.rs
@@ -1,10 +1,10 @@
 use {
     super::{create_request, Client, ResponseFuture},
-    crate::Error,
+    crate::error::Error,
     futures_util::{FutureExt, Stream},
     relay_rpc::{
         domain::Topic,
-        rpc::{BatchFetchMessages, SubscriptionData},
+        rpc::{BatchFetchMessages, ServiceRequest, SubscriptionData},
     },
     std::{
         pin::Pin,
@@ -48,7 +48,7 @@ impl FetchMessageStream {
 }
 
 impl Stream for FetchMessageStream {
-    type Item = Result<SubscriptionData, Error>;
+    type Item = Result<SubscriptionData, Error<<BatchFetchMessages as ServiceRequest>::Error>>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         loop {

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -52,6 +52,7 @@ alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1
 alloy-json-abi = { version = "0.6.2", optional = true }
 alloy-sol-types = { version = "0.6.2", optional = true }
 alloy-primitives = { version = "0.6.2", optional = true }
+strum = { version = "0.26", features = ["strum_macros", "derive"] }
 
 [dev-dependencies]
 tokio = { version = "1.35.1", features = ["test-util", "macros"] }

--- a/relay_rpc/src/rpc.rs
+++ b/relay_rpc/src/rpc.rs
@@ -535,6 +535,9 @@ pub enum PublishError {
 
     #[error("TTL too long")]
     TtlTooLong,
+
+    #[error("Mailbox limit exceeded")]
+    MailboxLimitExceeded,
 }
 
 impl ServiceRequest for Publish {

--- a/relay_rpc/src/rpc/error.rs
+++ b/relay_rpc/src/rpc/error.rs
@@ -136,7 +136,7 @@ impl<T: ServiceError> Error<T> {
             Self::Payload(err) => err.tag(),
             Self::Handler(err) => err.tag(),
             Self::Internal(err) => err.tag(),
-            Self::TooManyRequests => self.tag(),
+            Self::TooManyRequests => self.into(),
         }
     }
 }

--- a/relay_rpc/src/rpc/error.rs
+++ b/relay_rpc/src/rpc/error.rs
@@ -102,7 +102,7 @@ pub enum InternalError {
 /// into [`super::ErrorResponse`], and should be specific enough for the clients
 /// to make sense of the problem.
 #[derive(Debug, thiserror::Error, strum::IntoStaticStr, PartialEq, Eq)]
-pub enum Error<T: ServiceError> {
+pub enum Error<T> {
     #[error("Auth error: {0}")]
     Auth(#[from] AuthError),
 
@@ -122,11 +122,11 @@ pub enum Error<T: ServiceError> {
 impl<T: ServiceError> Error<T> {
     pub fn code(&self) -> i32 {
         match self {
-            Self::Auth(_) => ERROR_CODE_AUTH,
-            Self::TooManyRequests => ERROR_CODE_TOO_MANY_REQUESTS,
-            Self::Payload(_) => ERROR_CODE_PAYLOAD,
-            Self::Handler(_) => ERROR_CODE_HANDLER,
-            Self::Internal(_) => ERROR_CODE_INTERNAL,
+            Self::Auth(_) => CODE_AUTH,
+            Self::TooManyRequests => CODE_TOO_MANY_REQUESTS,
+            Self::Payload(_) => CODE_PAYLOAD,
+            Self::Handler(_) => CODE_HANDLER,
+            Self::Internal(_) => CODE_INTERNAL,
         }
     }
 
@@ -141,11 +141,11 @@ impl<T: ServiceError> Error<T> {
     }
 }
 
-pub const ERROR_CODE_AUTH: i32 = 3000;
-pub const ERROR_CODE_TOO_MANY_REQUESTS: i32 = 3001;
-pub const ERROR_CODE_PAYLOAD: i32 = -32600;
-pub const ERROR_CODE_HANDLER: i32 = -32000;
-pub const ERROR_CODE_INTERNAL: i32 = -32603;
+pub const CODE_AUTH: i32 = 3000;
+pub const CODE_TOO_MANY_REQUESTS: i32 = 3001;
+pub const CODE_PAYLOAD: i32 = -32600;
+pub const CODE_HANDLER: i32 = -32000;
+pub const CODE_INTERNAL: i32 = -32603;
 
 #[derive(Debug, thiserror::Error)]
 #[error("Invalid error data")]
@@ -158,11 +158,11 @@ impl<T: ServiceError> TryFrom<ErrorData> for Error<T> {
         let tag = &err.data;
 
         let err = match err.code {
-            ERROR_CODE_AUTH => Error::Auth(try_parse_error(tag)?),
-            ERROR_CODE_TOO_MANY_REQUESTS => Error::TooManyRequests,
-            ERROR_CODE_PAYLOAD => Error::Payload(try_parse_error(tag)?),
-            ERROR_CODE_HANDLER => Error::Handler(try_parse_error(tag)?),
-            ERROR_CODE_INTERNAL => Error::Internal(try_parse_error(tag)?),
+            CODE_AUTH => Error::Auth(try_parse_error(tag)?),
+            CODE_TOO_MANY_REQUESTS => Error::TooManyRequests,
+            CODE_PAYLOAD => Error::Payload(try_parse_error(tag)?),
+            CODE_HANDLER => Error::Handler(try_parse_error(tag)?),
+            CODE_INTERNAL => Error::Internal(try_parse_error(tag)?),
             _ => return Err(InvalidErrorData),
         };
 

--- a/relay_rpc/src/rpc/error.rs
+++ b/relay_rpc/src/rpc/error.rs
@@ -1,0 +1,186 @@
+use {
+    super::ErrorData,
+    std::fmt::{Debug, Display},
+};
+
+/// Provides serialization to and from string tags. This has a blanket
+/// implementation for all error types that derive [`strum::EnumString`] and
+/// [`strum::IntoStaticStr`].
+pub trait ServiceError: Sized + Debug + Display + PartialEq + Send + 'static {
+    fn from_tag(tag: &str) -> Result<Self, InvalidErrorData>;
+
+    fn tag(&self) -> &'static str;
+}
+
+impl<T> ServiceError for T
+where
+    T: for<'a> TryFrom<&'a str> + Debug + Display + PartialEq + Send + 'static,
+    for<'a> &'static str: From<&'a T>,
+{
+    fn from_tag(tag: &str) -> Result<Self, InvalidErrorData> {
+        tag.try_into().map_err(|_| InvalidErrorData)
+    }
+
+    fn tag(&self) -> &'static str {
+        self.into()
+    }
+}
+
+#[derive(Debug, thiserror::Error, strum::EnumString, strum::IntoStaticStr, PartialEq, Eq)]
+pub enum AuthError {
+    #[error("Project not found")]
+    ProjectNotFound,
+
+    #[error("Project ID not specified")]
+    ProjectIdNotSpecified,
+
+    #[error("Project inactive")]
+    ProjectInactive,
+
+    #[error("Origin not allowed")]
+    OriginNotAllowed,
+
+    #[error("Invalid JWT")]
+    InvalidJwt,
+
+    #[error("Missing JWT")]
+    MissingJwt,
+
+    #[error("Country blocked")]
+    CountryBlocked,
+}
+
+/// Request payload validation problems.
+#[derive(
+    Debug, Clone, thiserror::Error, strum::EnumString, strum::IntoStaticStr, PartialEq, Eq,
+)]
+pub enum PayloadError {
+    #[error("Invalid request method")]
+    InvalidMethod,
+
+    #[error("Invalid request parameters")]
+    InvalidParams,
+
+    #[error("Payload size exceeded")]
+    PayloadSizeExceeded,
+
+    #[error("Topic decoding failed")]
+    InvalidTopic,
+
+    #[error("Subscription ID decoding failed")]
+    InvalidSubscriptionId,
+
+    #[error("Invalid request ID")]
+    InvalidRequestId,
+
+    #[error("Invalid JSON RPC version")]
+    InvalidJsonRpcVersion,
+
+    #[error("The batch contains too many items")]
+    BatchLimitExceeded,
+
+    #[error("The batch contains no items")]
+    BatchEmpty,
+
+    #[error("Failed to deserialize request")]
+    Serialization,
+}
+
+#[derive(Debug, thiserror::Error, strum::EnumString, strum::IntoStaticStr, PartialEq, Eq)]
+pub enum InternalError {
+    #[error("Storage operation failed")]
+    StorageError,
+
+    #[error("Failed to serialize response")]
+    Serialization,
+
+    #[error("Internal error")]
+    Unknown,
+}
+
+/// Errors caught while processing the request. These are meant to be serialized
+/// into [`super::ErrorResponse`], and should be specific enough for the clients
+/// to make sense of the problem.
+#[derive(Debug, thiserror::Error, strum::IntoStaticStr, PartialEq, Eq)]
+pub enum Error<T: ServiceError> {
+    #[error("Auth error: {0}")]
+    Auth(#[from] AuthError),
+
+    #[error("Invalid payload: {0}")]
+    Payload(#[from] PayloadError),
+
+    #[error("Request handler error: {0}")]
+    Handler(T),
+
+    #[error("Internal error: {0}")]
+    Internal(#[from] InternalError),
+
+    #[error("Too many requests")]
+    TooManyRequests,
+}
+
+impl<T: ServiceError> Error<T> {
+    pub fn code(&self) -> i32 {
+        match self {
+            Self::Auth(_) => ERROR_CODE_AUTH,
+            Self::TooManyRequests => ERROR_CODE_TOO_MANY_REQUESTS,
+            Self::Payload(_) => ERROR_CODE_PAYLOAD,
+            Self::Handler(_) => ERROR_CODE_HANDLER,
+            Self::Internal(_) => ERROR_CODE_INTERNAL,
+        }
+    }
+
+    pub fn tag(&self) -> &'static str {
+        match &self {
+            Self::Auth(err) => err.tag(),
+            Self::Payload(err) => err.tag(),
+            Self::Handler(err) => err.tag(),
+            Self::Internal(err) => err.tag(),
+            Self::TooManyRequests => self.tag(),
+        }
+    }
+}
+
+pub const ERROR_CODE_AUTH: i32 = 3000;
+pub const ERROR_CODE_TOO_MANY_REQUESTS: i32 = 3001;
+pub const ERROR_CODE_PAYLOAD: i32 = -32600;
+pub const ERROR_CODE_HANDLER: i32 = -32000;
+pub const ERROR_CODE_INTERNAL: i32 = -32603;
+
+#[derive(Debug, thiserror::Error)]
+#[error("Invalid error data")]
+pub struct InvalidErrorData;
+
+impl<T: ServiceError> TryFrom<ErrorData> for Error<T> {
+    type Error = InvalidErrorData;
+
+    fn try_from(err: ErrorData) -> Result<Self, Self::Error> {
+        let tag = &err.data;
+
+        let err = match err.code {
+            ERROR_CODE_AUTH => Error::Auth(try_parse_error(tag)?),
+            ERROR_CODE_TOO_MANY_REQUESTS => Error::TooManyRequests,
+            ERROR_CODE_PAYLOAD => Error::Payload(try_parse_error(tag)?),
+            ERROR_CODE_HANDLER => Error::Handler(try_parse_error(tag)?),
+            ERROR_CODE_INTERNAL => Error::Internal(try_parse_error(tag)?),
+            _ => return Err(InvalidErrorData),
+        };
+
+        Ok(err)
+    }
+}
+
+#[inline]
+fn try_parse_error<T: ServiceError>(tag: &Option<String>) -> Result<T, InvalidErrorData> {
+    tag.as_deref().ok_or(InvalidErrorData).map(T::from_tag)?
+}
+
+impl<T: ServiceError> From<Error<T>> for ErrorData {
+    fn from(err: Error<T>) -> Self {
+        Self {
+            code: err.code(),
+            message: err.to_string(),
+            data: Some(err.tag().to_owned()),
+        }
+    }
+}

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -636,12 +636,21 @@ fn error_tags() {
     // compatibility with other SDKs as a result of refactoring.
 
     assert_eq!(
+        Error::<GenericError>::TooManyRequests.tag(),
+        "TooManyRequests"
+    );
+
+    assert_eq!(
         SubscriptionError::SubscriberLimitExceeded.tag(),
         "SubscriberLimitExceeded"
     );
 
     assert_eq!(PublishError::TtlTooShort.tag(), "TtlTooShort");
     assert_eq!(PublishError::TtlTooLong.tag(), "TtlTooLong");
+    assert_eq!(
+        PublishError::MailboxLimitExceeded.tag(),
+        "MailboxLimitExceeded"
+    );
 
     assert_eq!(GenericError::Unknown.tag(), "Unknown");
 

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -592,7 +592,7 @@ fn validation() {
     };
     assert_eq!(request.validate(), Ok(()));
 
-    // Batch receive: empty list.PayloadError
+    // Batch receive: empty list.
     let request = Request {
         id,
         jsonrpc: jsonrpc.clone(),

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -573,7 +573,7 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchFetchMessages(BatchFetchMessages {
             topics: vec![Topic::from(
-                "c4163cf6PayloadErrorc296e7765411178ed452d1c30337a6230138c98401",
+                "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c98401",
             )],
         }),
     };

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -281,7 +281,7 @@ fn validation() {
             prompt: false,
         }),
     };
-    assert_eq!(request.validate(), Err(ValidationError::RequestId));
+    assert_eq!(request.validate(), Err(PayloadError::InvalidRequestId));
 
     // Invalid JSONRPC version.
     let request = Request {
@@ -295,7 +295,7 @@ fn validation() {
             prompt: false,
         }),
     };
-    assert_eq!(request.validate(), Err(ValidationError::JsonRpcVersion));
+    assert_eq!(request.validate(), Err(PayloadError::InvalidJsonRpcVersion));
 
     // Publish: valid.
     let request = Request {
@@ -323,10 +323,7 @@ fn validation() {
             prompt: false,
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
 
     // Subscribe: valid.
     let request = Request {
@@ -348,10 +345,7 @@ fn validation() {
             block: false,
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
 
     // Unsubscribe: valid.
     let request = Request {
@@ -373,10 +367,7 @@ fn validation() {
             subscription_id: subscription_id.clone(),
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
 
     // Fetch: valid.
     let request = Request {
@@ -396,10 +387,7 @@ fn validation() {
             topic: Topic::from("invalid"),
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
 
     // Subscription: valid.
     let request = Request {
@@ -431,12 +419,7 @@ fn validation() {
             },
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::SubscriptionIdDecoding(
-            DecodingError::Length
-        ))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidSubscriptionId));
 
     // Subscription: invalid topic.
     let request = Request {
@@ -452,10 +435,7 @@ fn validation() {
             },
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
 
     // Batch subscription: valid.
     let request = Request {
@@ -477,7 +457,7 @@ fn validation() {
             block: false,
         }),
     };
-    assert_eq!(request.validate(), Err(ValidationError::BatchEmpty));
+    assert_eq!(request.validate(), Err(PayloadError::BatchEmpty));
 
     // Batch subscription: too many items.
     let topics = (0..MAX_SUBSCRIPTION_BATCH_SIZE + 1)
@@ -491,13 +471,7 @@ fn validation() {
             block: false,
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::BatchLimitExceeded {
-            limit: MAX_SUBSCRIPTION_BATCH_SIZE,
-            actual: MAX_SUBSCRIPTION_BATCH_SIZE + 1
-        })
-    );
+    assert_eq!(request.validate(), Err(PayloadError::BatchLimitExceeded));
 
     // Batch subscription: invalid topic.
     let request = Request {
@@ -510,10 +484,7 @@ fn validation() {
             block: false,
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
 
     // Batch unsubscription: valid.
     let request = Request {
@@ -536,7 +507,7 @@ fn validation() {
             subscriptions: vec![],
         }),
     };
-    assert_eq!(request.validate(), Err(ValidationError::BatchEmpty));
+    assert_eq!(request.validate(), Err(PayloadError::BatchEmpty));
 
     // Batch unsubscription: too many items.
     let subscriptions = (0..MAX_SUBSCRIPTION_BATCH_SIZE + 1)
@@ -550,13 +521,7 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchUnsubscribe(BatchUnsubscribe { subscriptions }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::BatchLimitExceeded {
-            limit: MAX_SUBSCRIPTION_BATCH_SIZE,
-            actual: MAX_SUBSCRIPTION_BATCH_SIZE + 1
-        })
-    );
+    assert_eq!(request.validate(), Err(PayloadError::BatchLimitExceeded));
 
     // Batch unsubscription: invalid topic.
     let request = Request {
@@ -571,10 +536,7 @@ fn validation() {
             }],
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
 
     // Batch fetch: valid.
     let request = Request {
@@ -592,7 +554,7 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchFetchMessages(BatchFetchMessages { topics: vec![] }),
     };
-    assert_eq!(request.validate(), Err(ValidationError::BatchEmpty));
+    assert_eq!(request.validate(), Err(PayloadError::BatchEmpty));
 
     // Batch fetch: too many items.
     let topics = (0..MAX_SUBSCRIPTION_BATCH_SIZE + 1)
@@ -603,13 +565,7 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchFetchMessages(BatchFetchMessages { topics }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::BatchLimitExceeded {
-            limit: MAX_SUBSCRIPTION_BATCH_SIZE,
-            actual: MAX_SUBSCRIPTION_BATCH_SIZE + 1
-        })
-    );
+    assert_eq!(request.validate(), Err(PayloadError::BatchLimitExceeded));
 
     // Batch fetch: invalid topic.
     let request = Request {
@@ -617,14 +573,11 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchFetchMessages(BatchFetchMessages {
             topics: vec![Topic::from(
-                "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c98401",
+                "c4163cf6PayloadErrorc296e7765411178ed452d1c30337a6230138c98401",
             )],
         }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
-    );
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
 
     // Batch receive: valid.
     let request = Request {
@@ -639,13 +592,13 @@ fn validation() {
     };
     assert_eq!(request.validate(), Ok(()));
 
-    // Batch receive: empty list.
+    // Batch receive: empty list.PayloadError
     let request = Request {
         id,
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchReceiveMessages(BatchReceiveMessages { receipts: vec![] }),
     };
-    assert_eq!(request.validate(), Err(ValidationError::BatchEmpty));
+    assert_eq!(request.validate(), Err(PayloadError::BatchEmpty));
 
     // Batch receive: too many items.
     let receipts = (0..MAX_RECEIVE_BATCH_SIZE + 1)
@@ -659,13 +612,7 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchReceiveMessages(BatchReceiveMessages { receipts }),
     };
-    assert_eq!(
-        request.validate(),
-        Err(ValidationError::BatchLimitExceeded {
-            limit: MAX_RECEIVE_BATCH_SIZE,
-            actual: MAX_RECEIVE_BATCH_SIZE + 1
-        })
-    );
+    assert_eq!(request.validate(), Err(PayloadError::BatchLimitExceeded));
 
     // Batch receive: invalid topic.
     let request = Request {
@@ -680,8 +627,62 @@ fn validation() {
             }],
         }),
     };
+    assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
+}
+
+#[test]
+fn error_tags() {
+    // Validate hardcoded string tags, so that we don't accidentally break
+    // compatibility with other SDKs as a result of refactoring.
+
     assert_eq!(
-        request.validate(),
-        Err(ValidationError::TopicDecoding(DecodingError::Length))
+        SubscriptionError::SubscriberLimitExceeded.tag(),
+        "SubscriberLimitExceeded"
     );
+
+    assert_eq!(PublishError::TtlTooShort.tag(), "TtlTooShort");
+    assert_eq!(PublishError::TtlTooLong.tag(), "TtlTooLong");
+
+    assert_eq!(GenericError::Unknown.tag(), "Unknown");
+
+    assert_eq!(WatchError::InvalidTtl.tag(), "InvalidTtl");
+    assert_eq!(WatchError::InvalidServiceUrl.tag(), "InvalidServiceUrl");
+    assert_eq!(WatchError::InvalidWebhookUrl.tag(), "InvalidWebhookUrl");
+    assert_eq!(WatchError::InvalidAction.tag(), "InvalidAction");
+    assert_eq!(WatchError::InvalidJwt.tag(), "InvalidJwt");
+
+    assert_eq!(AuthError::ProjectNotFound.tag(), "ProjectNotFound");
+    assert_eq!(
+        AuthError::ProjectIdNotSpecified.tag(),
+        "ProjectIdNotSpecified"
+    );
+    assert_eq!(AuthError::ProjectInactive.tag(), "ProjectInactive");
+    assert_eq!(AuthError::OriginNotAllowed.tag(), "OriginNotAllowed");
+    assert_eq!(AuthError::InvalidJwt.tag(), "InvalidJwt");
+    assert_eq!(AuthError::MissingJwt.tag(), "MissingJwt");
+    assert_eq!(AuthError::CountryBlocked.tag(), "CountryBlocked");
+
+    assert_eq!(PayloadError::InvalidMethod.tag(), "InvalidMethod");
+    assert_eq!(PayloadError::InvalidParams.tag(), "InvalidParams");
+    assert_eq!(
+        PayloadError::PayloadSizeExceeded.tag(),
+        "PayloadSizeExceeded"
+    );
+    assert_eq!(PayloadError::InvalidTopic.tag(), "InvalidTopic");
+    assert_eq!(
+        PayloadError::InvalidSubscriptionId.tag(),
+        "InvalidSubscriptionId"
+    );
+    assert_eq!(PayloadError::InvalidRequestId.tag(), "InvalidRequestId");
+    assert_eq!(
+        PayloadError::InvalidJsonRpcVersion.tag(),
+        "InvalidJsonRpcVersion"
+    );
+    assert_eq!(PayloadError::BatchLimitExceeded.tag(), "BatchLimitExceeded");
+    assert_eq!(PayloadError::BatchEmpty.tag(), "BatchEmpty");
+    assert_eq!(PayloadError::Serialization.tag(), "Serialization");
+
+    assert_eq!(InternalError::StorageError.tag(), "StorageError");
+    assert_eq!(InternalError::Serialization.tag(), "Serialization");
+    assert_eq!(InternalError::Unknown.tag(), "Unknown");
 }


### PR DESCRIPTION
# Description

This reworks the RPC errors to be serializable and deserializable from the `data` field of JSONRPC error response. Both the HTTP and websocket clients in this crate make use of the new errors by deserializing relay RPC responses into strongly-typed errors.

Clients in other SDKs should implement their own reconstruction based on the following JSONRPC error response fields:
- `code`: the general class of errors to distinguish between retryable and permanent errors;
- `data`: the string tag specifying error kind within that class;
- `message`: string message detailing the error.

The error codes are (mostly) consistent with the old error codes & the JSONRPC specs. What's changed:
- Parameter validation error code changed from `-32602` (invalid params) to a more generic `-32600` (invalid request);
- Payload size limit error code changed from `-32700` (parse error) to `-32600` (invalid request);

The rest of the changes are non-breaking, in terms of error codes.

- Relay integration: https://github.com/WalletConnect/rs-relay/pull/1436

## How Has This Been Tested?

Existing tests, relay integration tests and also new tests covering error tags.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
