### PR TITLE
chore: improve header error

### DIFF
--- a/relay_rpc/src/auth/cacao.rs
+++ b/relay_rpc/src/auth/cacao.rs
@@ -7,7 +7,10 @@ use {
     core::fmt::Debug,
     serde::{Deserialize, Serialize},
     serde_json::value::RawValue,
-    std::fmt::{Display, Write},
+    std::{
+        fmt::{Display, Write},
+        sync::Arc,
+    },
 };
 
 pub mod header;
@@ -17,8 +20,8 @@ pub mod signature;
 /// Errors that can occur during Cacao verification.
 #[derive(Debug, thiserror::Error)]
 pub enum CacaoError {
-    #[error("Invalid header")]
-    Header,
+    #[error("Header `t` value unsupported: {0}")]
+    HeaderTypeUnsupported(Arc<str>),
 
     #[error("Invalid or missing identity key in payload resources")]
     PayloadIdentityKey,

--- a/relay_rpc/src/auth/cacao/header.rs
+++ b/relay_rpc/src/auth/cacao/header.rs
@@ -1,20 +1,21 @@
 use {
     super::CacaoError,
     serde::{Deserialize, Serialize},
+    std::sync::Arc,
 };
 
 pub const EIP4361: &str = "eip4361";
 
 #[derive(Clone, Debug, PartialEq, Eq, Deserialize, Serialize, Hash)]
 pub struct Header {
-    pub t: String,
+    pub t: Arc<str>,
 }
 
 impl Header {
     pub fn validate(&self) -> Result<(), CacaoError> {
-        match self.t.as_str() {
+        match self.t.as_ref() {
             EIP4361 => Ok(()),
-            _ => Err(CacaoError::Header),
+            _ => Err(CacaoError::HeaderTypeUnsupported(self.t.clone())),
         }
     }
 }


### PR DESCRIPTION
# Description

"Invalid header" isn't a good error message, this improves the error message. The header is already parsed as a valid structure, all this does is check the type (`t`) field.

## How Has This Been Tested?

Not tested. Passes compilation, and nothing depends on this error. It's just used to help debugging a 400.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
