### PR TITLE
feat: seaprate blocking methods

### DIFF
--- a/relay_client/src/lib.rs
+++ b/relay_client/src/lib.rs
@@ -3,7 +3,8 @@ use {
     ::http::HeaderMap,
     relay_rpc::{
         auth::{SerializedAuthToken, RELAY_WEBSOCKET_ADDRESS},
-        domain::{MessageId, ProjectId},
+        domain::{MessageId, ProjectId, SubscriptionId},
+        rpc::{SubscriptionError, SubscriptionResult},
         user_agent::UserAgent,
     },
     serde::Serialize,
@@ -167,6 +168,16 @@ impl Default for MessageIdGenerator {
         Self {
             next: Arc::new(AtomicU8::new(0)),
         }
+    }
+}
+
+#[inline]
+fn convert_subscription_result(
+    res: SubscriptionResult,
+) -> Result<SubscriptionId, error::Error<SubscriptionError>> {
+    match res {
+        SubscriptionResult::Id(id) => Ok(id),
+        SubscriptionResult::Error(err) => Err(ClientError::from(err).into()),
     }
 }
 

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -249,6 +249,29 @@ fn deserialize_batch_methods() {
             })
         })
     );
+
+    let serialized =
+        r#"{ "id": "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840" }"#;
+    assert_eq!(
+        serde_json::from_str::<'_, SubscriptionResult>(serialized).unwrap(),
+        SubscriptionResult::Id(SubscriptionId::from(
+            "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840"
+        ))
+    );
+
+    let serialized = r#"{
+        "error": {
+            "code": -32600,
+            "message": "Invalid payload: The batch contains too many items",
+            "data": "BatchLimitExceeded"
+        }
+    }"#;
+    assert_eq!(
+        serde_json::from_str::<'_, SubscriptionResult>(serialized).unwrap(),
+        SubscriptionResult::Error(
+            Error::<SubscriptionError>::Payload(PayloadError::BatchLimitExceeded).into()
+        )
+    );
 }
 
 #[test]

--- a/relay_rpc/src/rpc/tests.rs
+++ b/relay_rpc/src/rpc/tests.rs
@@ -220,12 +220,10 @@ fn deserialize_batch_methods() {
         "params": {
             "subscriptions": [
                 {
-                    "topic": "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840",
-                    "id": "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9841"
+                    "topic": "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840"
                 },
                 {
-                    "topic": "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9842",
-                    "id": "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9843"
+                    "topic": "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9842"
                 }
             ]
         }
@@ -241,16 +239,10 @@ fn deserialize_batch_methods() {
                         topic: Topic::from(
                             "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9840"
                         ),
-                        subscription_id: SubscriptionId::from(
-                            "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9841"
-                        ),
                     },
                     Unsubscribe {
                         topic: Topic::from(
                             "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9842"
-                        ),
-                        subscription_id: SubscriptionId::from(
-                            "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c9843"
                         ),
                     }
                 ]
@@ -353,7 +345,6 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::Unsubscribe(Unsubscribe {
             topic: topic.clone(),
-            subscription_id: subscription_id.clone(),
         }),
     };
     assert_eq!(request.validate(), Ok(()));
@@ -364,7 +355,6 @@ fn validation() {
         jsonrpc: jsonrpc.clone(),
         params: Params::Unsubscribe(Unsubscribe {
             topic: Topic::from("invalid"),
-            subscription_id: subscription_id.clone(),
         }),
     };
     assert_eq!(request.validate(), Err(PayloadError::InvalidTopic));
@@ -491,10 +481,7 @@ fn validation() {
         id,
         jsonrpc: jsonrpc.clone(),
         params: Params::BatchUnsubscribe(BatchUnsubscribe {
-            subscriptions: vec![Unsubscribe {
-                topic,
-                subscription_id: subscription_id.clone(),
-            }],
+            subscriptions: vec![Unsubscribe { topic }],
         }),
     };
     assert_eq!(request.validate(), Ok(()));
@@ -513,7 +500,6 @@ fn validation() {
     let subscriptions = (0..MAX_SUBSCRIPTION_BATCH_SIZE + 1)
         .map(|_| Unsubscribe {
             topic: Topic::generate(),
-            subscription_id: SubscriptionId::generate(),
         })
         .collect();
     let request = Request {
@@ -532,7 +518,6 @@ fn validation() {
                 topic: Topic::from(
                     "c4163cf65859106b3f5435fc296e7765411178ed452d1c30337a6230138c98401",
                 ),
-                subscription_id,
             }],
         }),
     };


### PR DESCRIPTION
# Description

This creates a separate `irn_subscribeBlocking` and `irn_batchSubscribeBlocking` methods which were previously behind the `block` flag in the main method payloads.

Also removes the requirement to pass subscription IDs to unsubscribe.

## How Has This Been Tested?

Relay integration.

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
