### PR TITLE
fix: bump http deps

### DIFF
--- a/blockchain_api/Cargo.toml
+++ b/blockchain_api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 relay_rpc = { path = "../relay_rpc" }
-reqwest = "0.12.2"
+reqwest = { version = "0.12.2", features = ["json"] }
 serde = "1.0"
 tokio = { version = "1.0", features = ["test-util", "macros"] }
 tracing = "0.1.40"

--- a/blockchain_api/Cargo.toml
+++ b/blockchain_api/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 relay_rpc = { path = "../relay_rpc" }
-reqwest = "0.11"
+reqwest = "0.12.2"
 serde = "1.0"
 tokio = { version = "1.0", features = ["test-util", "macros"] }
 tracing = "0.1.40"

--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -17,14 +17,14 @@ serde_qs = "0.10"
 pin-project = "1.0"
 chrono = { version = "0.4", default-features = false, features = ["alloc", "std"] }
 url = "2.3"
-http = "0.2"
+http = "1.0.0"
 
 # HTTP client dependencies.
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12.2", features = ["json"] }
 
 # WebSocket client dependencies.
 tokio = { version = "1.22", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }
-tokio-tungstenite = "0.20"
+tokio-tungstenite = "0.21.0"
 futures-channel = "0.3"
 tokio-stream = "0.1"
 tokio-util = "0.7"

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -42,7 +42,7 @@ jsonwebtoken = "8.1"
 k256 = { version = "0.13", optional = true }
 sha3 = { version = "0.10", optional = true }
 sha2 = { version = "0.10.6" }
-reqwest = { version = "0.11", features = ["default-tls"] }
+reqwest = { version = "0.12.2", features = ["default-tls"] }
 url = "2"
 alloy-providers = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
 alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -42,7 +42,6 @@ jsonwebtoken = "8.1"
 k256 = { version = "0.13", optional = true }
 sha3 = { version = "0.10", optional = true }
 sha2 = { version = "0.10.6" }
-reqwest = { version = "0.12.2", features = ["default-tls"] }
 url = "2"
 alloy-providers = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }
 alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "e6f98e1", optional = true }


### PR DESCRIPTION
# Description

Bumps to the latest reqwest version and related dependencies. Necessary for the rennovatebot PR on Notify Server: https://github.com/WalletConnect/notify-server/pull/467

## How Has This Been Tested?

Existing tests and in https://github.com/WalletConnect/notify-server/pull/467

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
