### PR TITLE
fix: adding license to workspaces

### DIFF
--- a/blockchain_api/Cargo.toml
+++ b/blockchain_api/Cargo.toml
@@ -2,6 +2,7 @@
 name = "blockchain_api"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 relay_rpc = { path = "../relay_rpc", features = ["cacao"] }

--- a/relay_client/Cargo.toml
+++ b/relay_client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "relay_client"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [features]
 default = ["tokio-tungstenite/native-tls"]

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -2,6 +2,7 @@
 name = "relay_rpc"
 version = "0.1.0"
 edition = "2021"
+license = "Apache-2.0"
 
 [features]
 cacao = [


### PR DESCRIPTION
# Description

This PR adds a license to workspaces. The license type is the same as in the root package: [Apache-2.0](https://github.com/WalletConnect/WalletConnectRust/blob/2ce3a45f4d9ada7f05441a690a766ddf79f086f0/Cargo.toml#L7).
This should fix [license check errors](https://github.com/WalletConnect/blockchain-api/actions/runs/8849202224/job/24301511183?pr=644#step:4:17).

## How Has This Been Tested?

Not tested.

<!-- If valid for smoke test on feature add screenshots -->

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
