### PR TITLE
fix: bump alloy to latest

### DIFF
--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -42,6 +42,7 @@ strum = { version = "0.26", features = ["strum_macros", "derive"] }
 
 [dev-dependencies]
 tokio = { version = "1.35.1", features = ["test-util", "macros"] }
+alloy = { version = "0.3.6", features = ["node-bindings"] }
 
 [build-dependencies]
 serde_json = "1.0"

--- a/relay_rpc/Cargo.toml
+++ b/relay_rpc/Cargo.toml
@@ -8,16 +8,7 @@ license = "Apache-2.0"
 cacao = [
     "dep:k256",
     "dep:sha3",
-    "dep:alloy-provider",
-    "dep:alloy-transport",
-    "dep:alloy-transport-http",
-    "dep:alloy-rpc-types",
-    "dep:alloy-json-rpc",
-    "dep:alloy-json-abi",
-    "dep:alloy-sol-types",
-    "dep:alloy-primitives",
-    "dep:alloy-node-bindings",
-    "dep:alloy-contract"
+    "dep:alloy"
 ]
 
 [dependencies]
@@ -46,16 +37,7 @@ k256 = { version = "0.13", optional = true }
 sha3 = { version = "0.10", optional = true }
 sha2 = { version = "0.10.6" }
 url = "2"
-alloy-provider = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7", optional = true }
-alloy-transport = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7", optional = true }
-alloy-transport-http = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7", optional = true }
-alloy-rpc-types = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7", optional = true }
-alloy-json-rpc = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7", optional = true }
-alloy-node-bindings = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7", optional = true }
-alloy-contract = { git = "https://github.com/alloy-rs/alloy.git", rev = "d68a6b7", optional = true }
-alloy-json-abi = { version = "0.7.0", optional = true }
-alloy-sol-types = { version = "0.7.0", optional = true }
-alloy-primitives = { version = "0.7.0", optional = true }
+alloy = { version = "0.3.6", optional = true, features = ["json-rpc", "provider-http", "contract", "rpc-types-eth"] }
 strum = { version = "0.26", features = ["strum_macros", "derive"] }
 
 [dev-dependencies]

--- a/relay_rpc/src/auth/cacao.rs
+++ b/relay_rpc/src/auth/cacao.rs
@@ -52,10 +52,14 @@ pub enum CacaoError {
     Verification,
 
     #[error("Internal EIP-1271 resolution error: {0}")]
-    Eip1271Internal(alloy::rpc::json_rpc::RpcError<alloy::transports::TransportErrorKind, Box<RawValue>>),
+    Eip1271Internal(
+        alloy::rpc::json_rpc::RpcError<alloy::transports::TransportErrorKind, Box<RawValue>>,
+    ),
 
     #[error("Internal EIP-6492 resolution error: {0}")]
-    Eip6492Internal(alloy::rpc::json_rpc::RpcError<alloy::transports::TransportErrorKind, Box<RawValue>>),
+    Eip6492Internal(
+        alloy::rpc::json_rpc::RpcError<alloy::transports::TransportErrorKind, Box<RawValue>>,
+    ),
 }
 
 impl From<std::fmt::Error> for CacaoError {

--- a/relay_rpc/src/auth/cacao.rs
+++ b/relay_rpc/src/auth/cacao.rs
@@ -4,7 +4,7 @@ use {
         payload::Payload,
         signature::{get_rpc_url::GetRpcUrl, Signature},
     },
-    alloy_primitives::hex::FromHexError,
+    alloy::primitives::hex::FromHexError,
     core::fmt::Debug,
     serde::{Deserialize, Serialize},
     serde_json::value::RawValue,
@@ -52,10 +52,10 @@ pub enum CacaoError {
     Verification,
 
     #[error("Internal EIP-1271 resolution error: {0}")]
-    Eip1271Internal(alloy_json_rpc::RpcError<alloy_transport::TransportErrorKind, Box<RawValue>>),
+    Eip1271Internal(alloy::rpc::json_rpc::RpcError<alloy::transports::TransportErrorKind, Box<RawValue>>),
 
     #[error("Internal EIP-6492 resolution error: {0}")]
-    Eip6492Internal(alloy_json_rpc::RpcError<alloy_transport::TransportErrorKind, Box<RawValue>>),
+    Eip6492Internal(alloy::rpc::json_rpc::RpcError<alloy::transports::TransportErrorKind, Box<RawValue>>),
 }
 
 impl From<std::fmt::Error> for CacaoError {

--- a/relay_rpc/src/auth/cacao/signature/eip1271.rs
+++ b/relay_rpc/src/auth/cacao/signature/eip1271.rs
@@ -1,9 +1,12 @@
 use {
     super::CacaoError,
-    alloy::primitives::Address,
-    alloy::providers::{network::Ethereum, Provider, ReqwestProvider},
-    alloy::rpc::types::{TransactionInput, TransactionRequest},
-    alloy::{sol, sol_types::SolCall},
+    alloy::{
+        primitives::Address,
+        providers::{network::Ethereum, Provider, ReqwestProvider},
+        rpc::types::{TransactionInput, TransactionRequest},
+        sol,
+        sol_types::SolCall,
+    },
     url::Url,
 };
 
@@ -39,20 +42,17 @@ pub async fn verify_eip1271(
             .into(),
         ));
 
-    let result = provider
-        .call(&call_request)
-        .await
-        .map_err(|e| {
-            if let Some(error_response) = e.as_error_resp() {
-                if error_response.message.starts_with("execution reverted:") {
-                    CacaoError::Verification
-                } else {
-                    CacaoError::Eip1271Internal(e)
-                }
+    let result = provider.call(&call_request).await.map_err(|e| {
+        if let Some(error_response) = e.as_error_resp() {
+            if error_response.message.starts_with("execution reverted:") {
+                CacaoError::Verification
             } else {
                 CacaoError::Eip1271Internal(e)
             }
-        })?;
+        } else {
+            CacaoError::Eip1271Internal(e)
+        }
+    })?;
 
     let magic = result.get(..4);
     if let Some(magic) = magic {

--- a/relay_rpc/src/auth/cacao/signature/eip1271.rs
+++ b/relay_rpc/src/auth/cacao/signature/eip1271.rs
@@ -1,9 +1,9 @@
 use {
     super::CacaoError,
-    alloy_primitives::Address,
-    alloy_provider::{network::Ethereum, Provider, ReqwestProvider},
-    alloy_rpc_types::{TransactionInput, TransactionRequest},
-    alloy_sol_types::{sol, SolCall},
+    alloy::primitives::Address,
+    alloy::providers::{network::Ethereum, Provider, ReqwestProvider},
+    alloy::rpc::types::{TransactionInput, TransactionRequest},
+    alloy::{sol, sol_types::SolCall},
     url::Url,
 };
 
@@ -40,7 +40,7 @@ pub async fn verify_eip1271(
         ));
 
     let result = provider
-        .call(&call_request, Default::default())
+        .call(&call_request)
         .await
         .map_err(|e| {
             if let Some(error_response) = e.as_error_resp() {
@@ -81,7 +81,7 @@ mod test {
                 EIP1271_MOCK_CONTRACT,
             },
         },
-        alloy_primitives::address,
+        alloy::primitives::address,
         k256::ecdsa::SigningKey,
         sha3::{Digest, Keccak256},
     };

--- a/relay_rpc/src/auth/cacao/signature/eip191.rs
+++ b/relay_rpc/src/auth/cacao/signature/eip191.rs
@@ -58,7 +58,7 @@ mod tests {
             eip191::verify_eip191,
             test_helpers::{message_hash_internal, sign_message},
         },
-        alloy_primitives::Address,
+        alloy::primitives::Address,
         k256::ecdsa::SigningKey,
     };
 

--- a/relay_rpc/src/auth/cacao/signature/eip191.rs
+++ b/relay_rpc/src/auth/cacao/signature/eip191.rs
@@ -1,7 +1,7 @@
 use {
     super::CacaoError,
     crate::auth::cacao::signature::strip_hex_prefix,
-    alloy_primitives::Address,
+    alloy::primitives::Address,
     sha3::{Digest, Keccak256},
 };
 

--- a/relay_rpc/src/auth/cacao/signature/eip6492.rs
+++ b/relay_rpc/src/auth/cacao/signature/eip6492.rs
@@ -1,9 +1,9 @@
 use {
     crate::auth::cacao::CacaoError,
-    alloy_primitives::Address,
-    alloy_provider::{network::Ethereum, Provider, ReqwestProvider},
-    alloy_rpc_types::{TransactionInput, TransactionRequest},
-    alloy_sol_types::{sol, SolConstructor},
+    alloy::primitives::Address,
+    alloy::providers::{network::Ethereum, Provider, ReqwestProvider},
+    alloy::rpc::types::{TransactionInput, TransactionRequest},
+    alloy::{sol, sol_types::SolConstructor},
     url::Url,
 };
 
@@ -42,20 +42,17 @@ pub async fn verify_eip6492(
     let transaction_request =
         TransactionRequest::default().input(TransactionInput::new(bytes.into()));
 
-    let result = provider
-        .call(&transaction_request, Default::default())
-        .await
-        .map_err(|e| {
-            if let Some(error_response) = e.as_error_resp() {
-                if error_response.message == "execution reverted" {
-                    CacaoError::Verification
-                } else {
-                    CacaoError::Eip6492Internal(e)
-                }
+    let result = provider.call(&transaction_request).await.map_err(|e| {
+        if let Some(error_response) = e.as_error_resp() {
+            if error_response.message == "execution reverted" {
+                CacaoError::Verification
             } else {
                 CacaoError::Eip6492Internal(e)
             }
-        })?;
+        } else {
+            CacaoError::Eip6492Internal(e)
+        }
+    })?;
 
     let magic = result.first();
     if let Some(magic) = magic {
@@ -76,16 +73,12 @@ mod test {
         crate::auth::cacao::signature::{
             strip_hex_prefix,
             test_helpers::{
-                deploy_contract,
-                message_hash,
-                sign_message,
-                spawn_anvil,
-                CREATE2_CONTRACT,
+                deploy_contract, message_hash, sign_message, spawn_anvil, CREATE2_CONTRACT,
                 EIP1271_MOCK_CONTRACT,
             },
         },
-        alloy_primitives::{address, b256, Uint},
-        alloy_sol_types::{SolCall, SolValue},
+        alloy::primitives::{address, b256, Uint},
+        alloy::sol_types::{SolCall, SolValue},
         k256::ecdsa::SigningKey,
     };
 

--- a/relay_rpc/src/auth/cacao/signature/eip6492.rs
+++ b/relay_rpc/src/auth/cacao/signature/eip6492.rs
@@ -1,9 +1,12 @@
 use {
     crate::auth::cacao::CacaoError,
-    alloy::primitives::Address,
-    alloy::providers::{network::Ethereum, Provider, ReqwestProvider},
-    alloy::rpc::types::{TransactionInput, TransactionRequest},
-    alloy::{sol, sol_types::SolConstructor},
+    alloy::{
+        primitives::Address,
+        providers::{network::Ethereum, Provider, ReqwestProvider},
+        rpc::types::{TransactionInput, TransactionRequest},
+        sol,
+        sol_types::SolConstructor,
+    },
     url::Url,
 };
 
@@ -73,12 +76,18 @@ mod test {
         crate::auth::cacao::signature::{
             strip_hex_prefix,
             test_helpers::{
-                deploy_contract, message_hash, sign_message, spawn_anvil, CREATE2_CONTRACT,
+                deploy_contract,
+                message_hash,
+                sign_message,
+                spawn_anvil,
+                CREATE2_CONTRACT,
                 EIP1271_MOCK_CONTRACT,
             },
         },
-        alloy::primitives::{address, b256, Uint},
-        alloy::sol_types::{SolCall, SolValue},
+        alloy::{
+            primitives::{address, b256, Uint},
+            sol_types::{SolCall, SolValue},
+        },
         k256::ecdsa::SigningKey,
     };
 

--- a/relay_rpc/src/auth/cacao/signature/mod.rs
+++ b/relay_rpc/src/auth/cacao/signature/mod.rs
@@ -6,7 +6,7 @@ use {
         get_rpc_url::GetRpcUrl,
     },
     super::{Cacao, CacaoError},
-    alloy_primitives::Address,
+    alloy::primitives::Address,
     serde::{Deserialize, Serialize},
     sha3::{Digest, Keccak256},
     std::str::FromStr,

--- a/relay_rpc/src/auth/cacao/signature/test_helpers.rs
+++ b/relay_rpc/src/auth/cacao/signature/test_helpers.rs
@@ -1,7 +1,9 @@
 use {
     super::eip191::eip191_bytes,
-    alloy_node_bindings::{Anvil, AnvilInstance},
-    alloy_primitives::Address,
+    alloy::{
+        node_bindings::{Anvil, AnvilInstance},
+        primitives::Address,
+    },
     k256::ecdsa::SigningKey,
     regex::Regex,
     sha2::Digest,


### PR DESCRIPTION
# Description

Bumps alloy to the latest version; this is what Yttrium uses and Blockchain API uses both these libraries.

## How Has This Been Tested?

Not tested

## Due Diligence

* [ ] Breaking change
* [ ] Requires a documentation update
* [ ] Requires a e2e/integration test update
